### PR TITLE
Label /var/log/zaqar/zaqar.log with httpd_log_t

### DIFF
--- a/local_settings.sh
+++ b/local_settings.sh
@@ -82,6 +82,7 @@ install_policies() {
 	fcontext -N -a -t httpd_log_t $LOCALSTATEDIR/log/aodh/app.log
 	fcontext -N -a -t httpd_log_t $LOCALSTATEDIR/log/ceilometer/app.log
 	fcontext -N -a -t httpd_log_t $LOCALSTATEDIR/log/panko/app.log
+	fcontext -N -a -t httpd_log_t $LOCALSTATEDIR/log/zaqar/zaqar.log
 	fcontext -N -a -t neutron_exec_t $BINDIR/neutron-rootwrap-daemon
 	fcontext -N -a -t neutron_exec_t $BINDIR/neutron-vpn-agent"
 


### PR DESCRIPTION
Allowing both the WSGI app and websocket service to log to the file.

Resolves: rhbz#1456562
Signed-off-by: Lee Yarwood <lyarwood@redhat.com>