### PR TITLE
RabbitMQ: remove currently unused definitions

### DIFF
--- a/os-rabbitmq.te
+++ b/os-rabbitmq.te
@@ -3,11 +3,6 @@ policy_module(os-rabbitmq,0.1)
 gen_require(`
 	type init_tmp_t;
 	type rabbitmq_epmd_t;
-	type rabbitmq_beam_t;
-	type rabbitmq_var_lib_t;
-	type systemd_logind_t;
-	type cluster_t;
-	class dbus send_msg;
 	class file write;
 ')
 


### PR DESCRIPTION
These definitions were used by the rules commented out in commit
4e52ae2bda5949e445ec098ff061db53caf7124a and later removed entirely in
commit c2d92fe9ae0670f4d6b7371cd6d34fcb7bf5c50b.

Signed-off-by: Peter Lemenkov <lemenkov@redhat.com>