### PR TITLE
Add podman rules for OpenStack

### DIFF
--- a/os-podman.te
+++ b/os-podman.te
@@ -1,0 +1,7 @@
+policy_module(os-podman, 1.0)
+gen_require(`
+        type container_t;
+')
+#============= container_t ==============
+miscfiles_read_generic_certs(container_t)
+openvswitch_stream_connect(container_t)


### PR DESCRIPTION
Currently, services with container_t flag cannot access some of the
host content, such as the certificates (cert_t) and OpenVSwitch socket
(openvswitch_t socket).

This patch correct that situation.