### PR TITLE
Allow ryslog to write in container_file_t context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TARGETS?=os-ovs os-swift os-nova os-neutron os-mysql os-glance os-rsync os-rabbitmq os-keepalived os-keystone os-haproxy os-mongodb os-ipxe os-redis os-cinder os-httpd os-gnocchi os-collectd os-virt os-dnsmasq os-octavia os-podman
+TARGETS?=os-ovs os-swift os-nova os-neutron os-mysql os-glance os-rsync os-rabbitmq os-keepalived os-keystone os-haproxy os-mongodb os-ipxe os-redis os-cinder os-httpd os-gnocchi os-collectd os-virt os-dnsmasq os-octavia os-podman os-rsyslog
 MODULES?=${TARGETS:=.pp.bz2}
 DATADIR?=/usr/share
 LOCALDIR?=/usr/share/openstack-selinux/master

--- a/os-rsyslog.te
+++ b/os-rsyslog.te
@@ -1,0 +1,11 @@
+policy_module(os-rsyslog,0.1)
+
+gen_require(`
+        type container_file_t;
+        type syslogd_t;
+')
+
+# LP #1810422
+manage_files_pattern(syslogd_t, container_file_t, container_file_t)
+manage_dirs_pattern(syslogd_t, container_file_t, container_file_t)
+manage_lnk_files_pattern(syslogd_t, container_file_t, container_file_t)


### PR DESCRIPTION
Some services cannot write their own logs, like haproxy, and trow their
logs directly in /dev/log. Rsyslog has then to write the log content in
some file.

The location for all logs is in /var/log/containers/<service>, and the
parent directory /var/log/containers is mounted with ":rw,z" flag by the
crontab container, meaning all the content will see its context switched
to container_file_t.

This context currently prevents rsyslog writing haproxy logs in the standard
location /var/log/containers/haproxy.

We considered moving the haproxy logs to /var/log/haproxy location, but this
creates another issue regarding the log rotation itself.

More information are available on the related LP issue:
https://bugs.launchpad.net/tripleo/+bug/1810422