### PR TITLE
Allow openvswitch to manage its files/sockets in a container context

### DIFF
--- a/os-podman.te
+++ b/os-podman.te
@@ -1,6 +1,8 @@
 policy_module(os-podman, 1.0)
 gen_require(`
         type container_t;
+        type container_file_t;
+        type openvswitch_t;
         type puppet_etc_t;
 ')
 #============= container_t ==============
@@ -9,3 +11,7 @@ openvswitch_stream_connect(container_t)
 # for posterity: read_files_pattern includes dir accesses
 read_files_pattern(container_t, puppet_etc_t, puppet_etc_t)
 read_lnk_files_pattern(container_t, puppet_etc_t, puppet_etc_t)
+
+manage_files_pattern(openvswitch_t, container_file_t, container_file_t)
+manage_sock_files_pattern(openvswitch_t, container_file_t, container_file_t)
+allow openvswitch_t self:capability net_broadcast;


### PR DESCRIPTION
As we're using and managing openvswitch from within containers, we
must enable a couple of new policies so that it can actually manage
its socket and directories, especially if they are bind-mounts