### PR TITLE
os-neutron: Add pam authentication support

### DIFF
--- a/os-neutron.te
+++ b/os-neutron.te
@@ -114,3 +114,7 @@ allow neutron_t self:process setpgid;
 
 # Bugzilla 1581729
 corenet_udp_bind_dhcpc_port(neutron_t)
+
+# Bugzilla 1676954
+auth_use_pam(neutron_t)
+init_rw_utmp(neutron_t)


### PR DESCRIPTION
This should help with rootwrap issues.

Related: rhbz#1676954