### PR TITLE
Add boolean to optionally enable PBIS support for nova_t/neutron_t

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TARGETS?=os-ovs os-swift os-nova os-neutron os-mysql os-glance os-rsync os-rabbitmq os-keepalived os-keystone os-haproxy os-mongodb os-ipxe os-redis os-cinder os-httpd os-gnocchi os-collectd os-virt os-dnsmasq os-octavia os-podman os-rsyslog
+TARGETS?=os-ovs os-swift os-nova os-neutron os-mysql os-glance os-rsync os-rabbitmq os-keepalived os-keystone os-haproxy os-mongodb os-ipxe os-redis os-cinder os-httpd os-gnocchi os-collectd os-virt os-dnsmasq os-octavia os-podman os-rsyslog os-pbis
 MODULES?=${TARGETS:=.pp.bz2}
 DATADIR?=/usr/share
 LOCALDIR?=/usr/share/openstack-selinux/master
@@ -19,7 +19,7 @@ local_settings.sh: local_settings.sh.in
 	chmod 0755 $@
 
 clean:
-	rm -f *~ *.if *.tc *.pp *.pp.bz2 local_settings.sh
+	rm -f *~ *.tc *.pp *.pp.bz2 local_settings.sh
 	rm -rf tmp *.tar.gz
 
 tarball: .git/config

--- a/os-pbis.if
+++ b/os-pbis.if
@@ -1,0 +1,25 @@
+#
+# This comes from pbis-open's pbis.if
+# https://github.com/BeyondTrust/pbis-open/blob/master/config/linux/redhat/rhel/7.0/pbis.if (GPL v2)
+#
+########################################
+## <summary>
+##      Connect to pbis services.
+## </summary>
+## <param name="domain">
+##      <summary>
+##      Domain allowed access.
+##      </summary>
+## </param>
+#
+
+interface(`os_pbis_client',`
+        gen_require(`
+                class unix_stream_socket connectto;
+                class sock_file { write create unlink getattr };
+                type var_lib_t, unconfined_t;
+        ')
+
+        allow $1 unconfined_t:unix_stream_socket connectto;
+        allow $1 var_lib_t:sock_file write;
+')

--- a/os-pbis.te
+++ b/os-pbis.te
@@ -1,0 +1,13 @@
+policy_module(os-pbis,0.1)
+
+gen_require(`
+    type neutron_t;
+    type nova_t;
+')
+
+# Bug 1658815 - Temporary workaround until PBIS is updated
+gen_tunable(openstack_pbis_support, false)
+tunable_policy(`openstack_pbis_support',`
+    os_pbis_client(neutron_t)
+    os_pbis_client(nova_t)
+')


### PR DESCRIPTION
Because the boolean is disabled by default, we can't add tests but these are the AVC denials fixed:

type=AVC msg=audit(1544557830.595:1357): avc:  denied  { write } for  pid=10185 comm="sudo" name=".lsassd" dev="dm-3" ino=262401 scontext=system_u:system_r:nova_t:s0 tcontext=system_u:object_r:var_lib_t:s0 tclass=sock_file permissive=0
type=AVC msg=audit(1551481878.901:639): avc:  denied  { write } for  pid=8456 comm="sudo" name=".lsassd" dev="dm-3" ino=262405 scontext=system_u:system_r:neutron_t:s0 tcontext=system_u:object_r:var_lib_t:s0 tclass=sock_file permissive=0

This is a temporary workaround until PBIS upstream is updated. The boolean will be deprecated once that is the case.

Resolves: rhbz#1658815