### PR TITLE
Make sure that /var/log/pacemaker/* is of cluster_var_log_t type

### DIFF
--- a/local_settings.sh.in
+++ b/local_settings.sh.in
@@ -92,7 +92,9 @@ set_file_contexts()
 	fcontext -N -$1 -t swift_exec_t $BINDIR/swift-object-relinker
 	fcontext -N -$1 -t httpd_sys_content_t \"${ROOTDIR}httpboot(/.*)?\"
 	fcontext -N -$1 -t ssh_home_t \"$SHAREDSTATEDIR/nova/.ssh(/.*)?\"
-	fcontext -N -$1 -t tftpdir_t \"${ROOTDIR}tftpboot(/.*)?\""
+	fcontext -N -$1 -t tftpdir_t \"${ROOTDIR}tftpboot(/.*)?\"
+	fcontext -N -$1 -t cluster_var_log_t \"$LOCALSTATEDIR/log/pacemaker\.log.*\"
+	fcontext -N -$1 -t cluster_var_log_t \"$LOCALSTATEDIR/log/pacemaker(/.*)?\""
 
 	echo "$INPUT" | $SBINDIR/semanage import -N
 }


### PR DESCRIPTION
So this commit is fundamentally a workaround to be put in place until
the official selinux-policy fixes https://bugzilla.redhat.com/show_bug.cgi?id=1712058
make it into a supported distro.

The rationale is the following: via https://github.com/redhat-openstack/openstack-selinux/pull/31
we allowed containers to write and manage files/dirs that have the
cluster_var_log_t type. The problem is that on RHEL8.0 the official policy (until
rhbz#1712058 is fixed) labels /var/log/pacemaker/bundles with
var_log_t instead. So we will get errors like the following:

  type=AVC msg=audit(1566400443.299:224052): avc:  denied  { write } for pid=530083 comm="python" name="btmp" dev="vda2" ino=31700395 scontext=system_u:system_r:container_t:s0:c590,c683 tcontext=system_u:object_r:var_log_t:s0 tclass=file permissive=0
  type=AVC msg=audit(1566401139.130:228828): avc:  denied  { write } for pid=559096 comm="python" name="btmp" dev="vda2" ino=31700395 scontext=system_u:system_r:container_t:s0:c841,c880 tcontext=system_u:object_r:var_log_t:s0 tclass=file permissive=0
  type=AVC msg=audit(1566401210.316:229325): avc:  denied  { write } for pid=562314 comm="python" name="btmp" dev="vda2" ino=31700395 scontext=system_u:system_r:container_t:s0:c136,c787 tcontext=system_u:object_r:var_log_t:s0 tclass=file permissive=0

So let's anticipate the upcoming selinux change and bring it in
openstack-selinux policy. We can drop it once we're positive
none will upgrade to a newer openstack-selinux without the updated
selinux-policy-targeted package.

Tested as follows:
0) Verified the problem after a fresh deployment:
[root@controller-0  ~]# restorecon -Rv  /var/log/pacemaker/bundles
Relabeled  /var/log/pacemaker/bundles/galera-bundle-0 from system_u:object_r:cluster_var_log_t:s0 to system_u:object_r:var_log_t:s0
Relabeled  /var/log/pacemaker/bundles/galera-bundle-0/mysql from system_u:object_r:cluster_var_log_t:s0 to system_u:object_r:var_log_t:s0

1) On a different node built and installed openstack-selinux rpm with this change
Tried a relabel and observed no relabels were needed:
[root@controller-1 ~]# restorecon -Rv /var/log/pacemaker/bundles/
[root@controller-1 ~]#

2) On the second node (1), reinstalled selinux-policy-targeted and
observed that still no relabeling was necessary:
[root@controller-1 ~]# restorecon -Rv /var/log/pacemaker/bundles/
[root@controller-1 ~]#

Closes-Bug: rhbz#1744259
Co-Authored-By: Damien Ciabrini <dciabrin@redhat.com>