### PR TITLE
local_settings: Fix file context addition on upgrade

### DIFF
--- a/local_settings.sh.in
+++ b/local_settings.sh.in
@@ -96,7 +96,15 @@ set_file_contexts()
 	fcontext -N -$1 -t cluster_var_log_t \"$LOCALSTATEDIR/log/pacemaker\.log.*\"
 	fcontext -N -$1 -t cluster_var_log_t \"$LOCALSTATEDIR/log/pacemaker(/.*)?\""
 
-	echo "$INPUT" | $SBINDIR/semanage import -N
+	# Load these one by one so upgrades work properly.
+	# TODO (future): Make upgrades (only) do one by one;
+	#                install/remove can do batches to save time.
+	while read; do
+		eval semanage $REPLY &> /dev/null
+	done < <(echo "$INPUT")
+
+	# TODO (future): install/remove can do this to save time
+	# echo "$INPUT" | $SBINDIR/semanage import -N
 }
 
 


### PR DESCRIPTION
This is an order of magnitude slower than batching things,
however, it fixes the issue where conflicts prevent new
file context overrides from being loaded.

Signed-off-by: Lon Hohberger <lon@metamorphism.com>