### PR TITLE
Ensure SELinux type is correct for a couple of directories

### DIFF
--- a/local_settings.sh.in
+++ b/local_settings.sh.in
@@ -85,6 +85,8 @@ set_file_contexts()
 	fcontext -N -$1 -t httpd_log_t $LOCALSTATEDIR/log/ceilometer/app.log
 	fcontext -N -$1 -t httpd_log_t $LOCALSTATEDIR/log/panko/app.log
 	fcontext -N -$1 -t httpd_log_t $LOCALSTATEDIR/log/zaqar/zaqar.log
+	fcontext -N -$1 -t container_file_t \"$LOCALSTATEDIR/log/containers/(.*)?\"
+	fcontext -N -$1 -t var_log_t \"$LOCALSTATEDIR/log/containers(/haproxy)?\"
 	fcontext -N -$1 -t neutron_exec_t $BINDIR/neutron-rootwrap-daemon
 	fcontext -N -$1 -t neutron_exec_t $BINDIR/neutron-vpn-agent
 	fcontext -N -$1 -t swift_var_cache_t \"$LOCALSTATEDIR/cache/swift(/.*)\"


### PR DESCRIPTION
Until now, when the openstack-selinux package is updated, it will revert
the content of /var/log/containers to var_log_t. This is breaking
OpenStack, since containers bind-mount a specific directory and write
their logs directly in it.

For instance, "nova" will bind-mount /var/log/containers/nova in
/var/log/nova, and write its logs directly, meaning we need to ensure
the host directory type is set to svirt_sandbox_file_t.

Related to: https://bugzilla.redhat.com/show_bug.cgi?id=1747948