### PR TITLE
Drop HAProxy log exception

### DIFF
--- a/local_settings.sh.in
+++ b/local_settings.sh.in
@@ -85,8 +85,7 @@ set_file_contexts()
 	fcontext -N -$1 -t httpd_log_t $LOCALSTATEDIR/log/ceilometer/app.log
 	fcontext -N -$1 -t httpd_log_t $LOCALSTATEDIR/log/panko/app.log
 	fcontext -N -$1 -t httpd_log_t $LOCALSTATEDIR/log/zaqar/zaqar.log
-	fcontext -N -$1 -t container_file_t \"$LOCALSTATEDIR/log/containers/(.*)?\"
-	fcontext -N -$1 -t var_log_t \"$LOCALSTATEDIR/log/containers(/haproxy)?\"
+	fcontext -N -$1 -t container_file_t \"$LOCALSTATEDIR/log/containers(/.*)?\"
 	fcontext -N -$1 -t neutron_exec_t $BINDIR/neutron-rootwrap-daemon
 	fcontext -N -$1 -t neutron_exec_t $BINDIR/neutron-vpn-agent
 	fcontext -N -$1 -t swift_var_cache_t \"$LOCALSTATEDIR/cache/swift(/.*)\"


### PR DESCRIPTION
Although the HAProxy logs are written by host syslog, there is no need
to worry about syslog access permissions:
f9b45ce introduced a new policy allowing syslogd_t to have full access on container_file_t files
and directories.

This patch is therefore more a cleanup and consistency work, in order to
keep a clean tree. It should also speed up a bit, since applying labels
take some time.