### PR TITLE
Allow logrotate to access and write within container_file_t

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TARGETS?=os-ovs os-swift os-nova os-neutron os-mysql os-glance os-rsync os-rabbitmq os-keepalived os-keystone os-haproxy os-mongodb os-ipxe os-redis os-cinder os-httpd os-gnocchi os-collectd os-virt os-dnsmasq os-octavia os-podman os-rsyslog os-pbis os-barbican os-sensu
+TARGETS?=os-ovs os-swift os-nova os-neutron os-mysql os-glance os-rsync os-rabbitmq os-keepalived os-keystone os-haproxy os-mongodb os-ipxe os-redis os-cinder os-httpd os-gnocchi os-collectd os-virt os-dnsmasq os-octavia os-podman os-rsyslog os-pbis os-barbican os-sensu os-logrotate
 MODULES?=${TARGETS:=.pp.bz2}
 DATADIR?=/usr/share
 LOCALDIR?=/usr/share/openstack-selinux/master

--- a/os-logrotate.te
+++ b/os-logrotate.te
@@ -1,0 +1,9 @@
+policy_module(os-logrotate,0.1)
+
+# Bugzilla 1727937
+gen_require(`
+  type logrotate_t;
+  type container_file_t;
+')
+manage_files_pattern(logrotate_t, container_file_t, container_file_t)
+manage_dirs_pattern(logrotate_t, container_file_t, container_file_t)

--- a/tests/bz1727937
+++ b/tests/bz1727937
@@ -1,0 +1,4 @@
+type=AVC msg=audit(1567480861.728:31696): avc:  denied  { write } for  pid=683284 comm="logrotate" name="openvswitch" dev="sda2" ino=2881762 scontext=system_u:system_r:logrotate_t:s0-s0:c0.c1023 tcontext=system_u:object_r:container_file_t:s0 tclass=dir permissive=0
+type=AVC msg=audit(1562508548.724:40): avc:  denied  { execute_no_trans } for  pid=1212 comm="modprobe" path="/usr/bin/bash" dev="vda2" ino=4215568 scontext=system_u:system_r:openvswitch_load_module_t:s0 tcontext=system_u:object_r:shell_exec_t:s0 tclass=file permissive=0
+type=AVC msg=audit(1562513521.955:5768): avc:  denied  { read } for  pid=54302 comm="logrotate" name="openvswitch" dev="vda2" ino=1012142 scontext=system_u:system_r:logrotate_t:s0-s0:c0.c1023 tcontext=system_u:object_r:container_file_t:s0 tclass=dir permissive=0
+


### PR DESCRIPTION
OpenVSwitch service gets its logs written in /var/log/openvswitch, using
container_file_t context.
Although we allowed logrotate to read container_file_t with[1], it also
wants to actually write in there, since the /var/log/openvswitch
directory is under its control, from within the host directly.

[1] https://review.opendev.org/669987

Related: https://bugzilla.redhat.com/show_bug.cgi?id=1727937