### PR TITLE
Allow spc_t to create unlabeled_t keyrings

### DIFF
--- a/os-virt.te
+++ b/os-virt.te
@@ -6,6 +6,7 @@ gen_require(`
 	type virtlogd_t;
 	type svirt_t;
 	type spc_t;
+	type unlabeled_t;
 	class dbus send_msg;
 	class fifo_file write;
 	class tun_socket attach_queue;
@@ -29,3 +30,6 @@ tunable_policy(`os_virtlogd_use_nfs',`
 
 # Bugzilla 1642102
 allow svirt_t spc_t:tun_socket attach_queue;
+
+# Bugzilla 1751300
+allow spc_t unlabeled_t:key manage_key_perms;

--- a/tests/bz1751300
+++ b/tests/bz1751300
@@ -1,0 +1,1 @@
+type=AVC msg=audit(1568239901.789:19443): avc:  denied  { create } for  pid=186828 comm="runc:[2:INIT]" scontext=system_u:system_r:spc_t:s0 tcontext=system_u:object_r:unlabeled_t:s0 tclass=key permissive=0


### PR DESCRIPTION
This is already allowed in more recent versions of container-selinux
(cf. commit 3b78187c).

Resolves: rhbz#1751300