### PR TITLE
Remove build-time warnings

### DIFF
--- a/os-neutron.te
+++ b/os-neutron.te
@@ -69,7 +69,7 @@ allow neutron_t self:netlink_xfrm_socket { bind create nlmsg_write };
 ipsec_exec_mgmt(neutron_t)
 ipsec_manage_key_file(neutron_t)
 ipsec_read_config(neutron_t)
-seutil_exec_restorecon(neutron_t)
+seutil_exec_setfiles(neutron_t)
 
 # Bugzilla 1280083
 allow neutron_t httpd_config_t:dir search;

--- a/tests/bz1727937
+++ b/tests/bz1727937
@@ -1,4 +1,3 @@
 type=AVC msg=audit(1567480861.728:31696): avc:  denied  { write } for  pid=683284 comm="logrotate" name="openvswitch" dev="sda2" ino=2881762 scontext=system_u:system_r:logrotate_t:s0-s0:c0.c1023 tcontext=system_u:object_r:container_file_t:s0 tclass=dir permissive=0
-type=AVC msg=audit(1562508548.724:40): avc:  denied  { execute_no_trans } for  pid=1212 comm="modprobe" path="/usr/bin/bash" dev="vda2" ino=4215568 scontext=system_u:system_r:openvswitch_load_module_t:s0 tcontext=system_u:object_r:shell_exec_t:s0 tclass=file permissive=0
 type=AVC msg=audit(1562513521.955:5768): avc:  denied  { read } for  pid=54302 comm="logrotate" name="openvswitch" dev="vda2" ino=1012142 scontext=system_u:system_r:logrotate_t:s0-s0:c0.c1023 tcontext=system_u:object_r:container_file_t:s0 tclass=dir permissive=0
 


### PR DESCRIPTION
- libsepol.context_from_record: type openvswitch_load_module_t is not defined
libsepol.context_from_record: could not create context structure
libsepol.context_from_string: could not create context structure
libsepol.sepol_context_to_sid: could not convert system_u:system_r:openvswitch_load_module_t:s0 to sid

Although openvswitch_load_module_t shows up in one of the tests, we
don't actually do anything related to it and the type isn't defined
anywhere in policy. This is handled by openvswitch-selinux-extra-policy.

- os-neutron.te:72: Warning: seutil_exec_restorecon(neutron_t) has been deprecated, please use seutil_exec_setfiles() instead.

seutil_exec_restorecon redirects straight to seutil_exec_setfiles [1]
and has done so since 2007. The deprecation was already present in the
selinux-policy shipped with RHEL 7.0 so using the new interface should
be safe.

[1] https://github.com/fedora-selinux/selinux-policy/blob/c8c08d777f/policy/modules/system/selinuxutil.if#L402-L405