### PR TITLE
Add some policies for Certmonger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-TARGETS?=os-ovs os-swift os-nova os-neutron os-mysql os-glance os-rsync os-rabbitmq os-keepalived os-keystone os-haproxy os-mongodb os-ipxe os-redis os-cinder os-httpd os-gnocchi os-collectd os-virt os-dnsmasq os-octavia os-podman os-rsyslog os-pbis os-barbican os-sensu os-logrotate
+TARGETS?=os-ovs os-swift os-nova os-neutron os-mysql os-glance os-rsync os-rabbitmq os-keepalived os-keystone os-haproxy os-mongodb os-ipxe os-redis os-cinder os-httpd os-gnocchi os-collectd os-virt os-dnsmasq os-octavia os-podman os-rsyslog os-pbis os-barbican os-sensu os-logrotate os-certmonger
 MODULES?=${TARGETS:=.pp.bz2}
 DATADIR?=/usr/share
 LOCALDIR?=/usr/share/openstack-selinux/master

--- a/os-certmonger.te
+++ b/os-certmonger.te
@@ -1,0 +1,10 @@
+policy_module(os-certmonger,0.1)
+
+gen_require(`
+  type certmonger_t;
+  type puppet_etc_t;
+  class dir {search};
+')
+# rhbz#1777263
+allow certmonger_t puppet_etc_t:dir search;
+read_files_pattern(certmonger_t, puppet_etc_t, puppet_etc_t)

--- a/tests/bz1777263
+++ b/tests/bz1777263
@@ -1,0 +1,3 @@
+type=AVC msg=audit(1574861307.690:5254): avc:  denied  { getattr } for  pid=25373 comm="ruby" path="/etc/puppet/hiera.yaml" dev="sda1" ino=150996716 scontext=system_u:system_r:certmonger_t:s0 tcontext=system_u:object_r:puppet_etc_t:s0 tclass=file permissive=1
+type=AVC msg=audit(1574861307.690:5255): avc:  denied  { read } for  pid=25373 comm="ruby" name="hiera.yaml" dev="sda1" ino=150996716 scontext=system_u:system_r:certmonger_t:s0 tcontext=system_u:object_r:puppet_etc_t:s0 tclass=file permissive=1
+type=AVC msg=audit(1574861307.690:5255): avc:  denied  { open } for  pid=25373 comm="ruby" path="/etc/puppet/hiera.yaml" dev="sda1" ino=150996716 scontext=system_u:system_r:certmonger_t:s0 tcontext=system_u:object_r:puppet_etc_t:s0 tclass=file permissive=1


### PR DESCRIPTION
Apparently, Certmonger lacks some privileges in a containerized
environment. This patch intends to fix part of the obvious issues raised
in the following rhbz:
https://bugzilla.redhat.com/show_bug.cgi?id=1777368
https://bugzilla.redhat.com/show_bug.cgi?id=1777263

Further work might be needed, but it is not sure new policies will be
added to os-certmonger.te.