### PR TITLE
Allow certmonger to actually manage containers

### DIFF
--- a/os-certmonger.te
+++ b/os-certmonger.te
@@ -8,3 +8,7 @@ gen_require(`
 # rhbz#1777263
 allow certmonger_t puppet_etc_t:dir search;
 read_files_pattern(certmonger_t, puppet_etc_t, puppet_etc_t)
+
+# rhbz#1777368
+container_runtime_domtrans(certmonger_t)
+container_runtime_entrypoint(certmonger_t)


### PR DESCRIPTION
Certmonger needs to run ps, exec and kill on containers in order to
update the certificates used by the service within them.

The following patch allow certmonger_t to "transition" to container_t
and run the wanted commands.

To my knowledge, we can't push example AVCs in the "test" directory
because the transition is something the current test can't properly
catch.

This fixes rhbz#1777368
https://bugzilla.redhat.com/show_bug.cgi?id=1777368

Co-Authored-By: Julie Pichon <jpichon@redhat.com>