### PR TITLE
Use alternative for container_runtime_entrypoint

### DIFF
--- a/os-certmonger.te
+++ b/os-certmonger.te
@@ -11,4 +11,4 @@ read_files_pattern(certmonger_t, puppet_etc_t, puppet_etc_t)
 
 # rhbz#1777368
 container_runtime_domtrans(certmonger_t)
-container_runtime_entrypoint(certmonger_t)
+allow certmonger_t container_runtime_exec_t:file entrypoint;


### PR DESCRIPTION
"container_runtime_entrypoint" interface is not available
in selinux-policy-devel(it includes container-selinux updates) package
available in CentOS7. To unblock package builds in RDO[1],
let's use selinux rule directly instead of using interface.

[1] https://review.rdoproject.org/r/#/c/23885/