### PR TITLE
Systemd needs to access container_file_t for side-cars

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,7 @@ install:
 
 	# Install tests
 	${INSTALL} -d ${LOCALDIR}/tests
-	${INSTALL} -m 0644 tests/bz* ${LOCALDIR}/tests
+	${INSTALL} -m 0644 tests/bz* tests/lp* ${LOCALDIR}/tests
 	${INSTALL} -m 0755 tests/check_all ${LOCALDIR}/tests
 
 	# Install interfaces

--- a/os-podman.te
+++ b/os-podman.te
@@ -5,6 +5,7 @@ gen_require(`
         type openvswitch_t;
         type puppet_etc_t;
         type cluster_var_log_t;
+        type init_t;
 ')
 #============= container_t ==============
 miscfiles_read_generic_certs(container_t)
@@ -23,3 +24,6 @@ allow openvswitch_t self:capability net_broadcast;
 # needed for HA containers
 manage_files_pattern(container_t, cluster_var_log_t, cluster_var_log_t);
 manage_dirs_pattern(container_t, cluster_var_log_t, cluster_var_log_t);
+
+# Needed for LP#1853652
+allow init_t container_file_t:file { execute execute_no_trans };

--- a/tests/check_all
+++ b/tests/check_all
@@ -17,7 +17,7 @@ mkdir -p $TMP
 PWD=$(pwd)
 cd "$(dirname $0)"
 
-TEST_FILES=$(/bin/ls -1 bz*)
+TEST_FILES=$(/bin/ls -1 bz* lp*)
 TEST_INPUT=$TMP/input
 TEST_OUTPUT=$TMP/output
 TEST_FAIL=$TMP/failed_tests

--- a/tests/lp1853652
+++ b/tests/lp1853652
@@ -1,0 +1,3 @@
+type=AVC msg=audit(1576568492.577:8193): avc:  denied  { execute } for  pid=77376 comm="(sync)" name="sync" dev="vda1" ino=236350363 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:container_file_t:s0 tclass=file permissive=1
+type=AVC msg=audit(1576568492.577:8193): avc:  denied  { execute_no_trans } for  pid=77376 comm="(sync)" path="/var/lib/neutron/dhcp_dnsmasq/sync" dev="vda1" ino=236350363 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:container_file_t:s0 tclass=file permissive=1
+


### PR DESCRIPTION
Neutron "side-cars" containers are now managed by Systemd instead of
in-container wrappers.
Basically, Systemd is instructed to check a certain location and take
action upon file creation|change|deletion. Since this "flag" is managed
from within neutron container(s), Systemd must be allowed to go in
there.

Related: https://bugs.launchpad.net/tripleo/+bug/1853652