### PR TITLE
Ensure fcontext has a rule for /var/lib/config-data

### DIFF
--- a/local_settings.sh.in
+++ b/local_settings.sh.in
@@ -86,6 +86,7 @@ set_file_contexts()
 	fcontext -N -$1 -t httpd_log_t $LOCALSTATEDIR/log/panko/app.log
 	fcontext -N -$1 -t httpd_log_t $LOCALSTATEDIR/log/zaqar/zaqar.log
 	fcontext -N -$1 -t container_file_t \"$LOCALSTATEDIR/log/containers(/.*)?\"
+	fcontext -N -$1 -t container_file_t \"$LOCALSTATEDIR/lib/config-data(/.*)?\"
 	fcontext -N -$1 -t neutron_exec_t $BINDIR/neutron-rootwrap-daemon
 	fcontext -N -$1 -t neutron_exec_t $BINDIR/neutron-vpn-agent
 	fcontext -N -$1 -t swift_var_cache_t \"$LOCALSTATEDIR/cache/swift(/.*)\"


### PR DESCRIPTION
Currently, running a restorecon on the system will change the selinux
type for /var/lib/config-data. This change might break an on-going
deploy or even running containers at some point.