### PR TITLE
Allow httpd to handle files in cinder statedir

### DIFF
--- a/os-cinder.te
+++ b/os-cinder.te
@@ -7,7 +7,7 @@ gen_require(`
         type cinder_volume_t;
         type cinder_var_lib_t;
         type httpd_t;
-        class file { open create };
+        class file { open create append getattr lock };
         class dir { add_name write create };
         class dbus { send_msg };
         attribute cinder_domain;
@@ -19,6 +19,9 @@ allow httpd_t cinder_log_t:dir { add_name write };
 
 # Bugzilla 1820504
 allow httpd_t cinder_var_lib_t:dir { add_name write create };
+
+# Allow httpd to handle files in statedir
+allow httpd_t cinder_var_lib_t:file { open create append getattr lock };
 
 # Bugzilla 1384472
 iscsid_domtrans(cinder_backup_t);


### PR DESCRIPTION
The statedir is used for locking files during
operations such as managing volume attachments.

I've censored our hypervisor name in the output below with `<hypervisor name>`

Example API failure when it cannot handle files in statedir:
2020-04-24 10:59:56.521 2451687 ERROR cinder.api.v3.attachments IOError: [Errno 13] Permission denied: u'/var/lib/cinder/cinder-attachment_update-70bcae94-0cad-45a0-9ab0-d6eaaef35c50-<hypervisor name>'

From audit log:

type=AVC msg=audit(1587719480.723:9252596): avc:  denied  { append open } for  pid=3907385 comm="httpd" path="/var/lib/cinder/cinder-attachment_update-b3b103ae-78a6-424f-b406-642d177c6c20-<hypervisor name>" dev="dm-0" ino=135032832 scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:object_r:cinder_var_lib_t:s0 tclass=file

type=AVC msg=audit(1587719779.203:2939539): avc:  denied  { getattr } for  pid=2451695 comm="httpd" path="/var/lib/cinder/cinder-attachment_update-243361c4-189a-423c-963a-89beefac2135-<hypervisor name>" dev="dm-0" ino=134395353 scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:object_r:cinder_var_lib_t:s0 tclass=file

type=AVC msg=audit(1587720082.812:2942608): avc:  denied  { lock } for  pid=2451695 comm="httpd" path="/var/lib/cinder/cinder-attachment_update-243361c4-189a-423c-963a-89beefac2135-<hypervisor name>" dev="dm-0" ino=134395353 scontext=system_u:system_r:httpd_t:s0 tcontext=system_u:object_r:cinder_var_lib_t:s0 tclass=file

