### PR TITLE
Allow execute_no_trans on neutron_exec_t

### DIFF
--- a/os-neutron.te
+++ b/os-neutron.te
@@ -4,6 +4,7 @@ gen_require(`
 	type neutron_t;
 	type neutron_var_lib_t;
 	type neutron_tmp_t;
+	type neutron_exec_t;
 	type haproxy_exec_t;
 	type haproxy_t;
 	type httpd_config_t;
@@ -45,6 +46,7 @@ neutron_domtrans(keepalived_t)
 
 # Bugzilla 1169859 & 1171460 & 1171458
 can_exec(neutron_t,neutron_var_lib_t)
+can_exec(neutron_t,neutron_exec_t)
 keepalived_domtrans(neutron_t)
 allow neutron_t self:netlink_socket { bind create getattr };
 


### PR DESCRIPTION
When running on CentOS 8 the openvswitch daemon
cannot spawn the rootwrap daemon.

Neutron log:
2020-06-15 07:29:17.691 3842 ERROR neutron Exception: Failed to spawn rootwrap process.
2020-06-15 07:29:17.691 3842 ERROR neutron stderr:
2020-06-15 07:29:17.691 3842 ERROR neutron b'sudo: unable to execute /usr/bin/neutron-rootwrap-daemon: Permission denied\n'

or with the standard rootwrap helper (not the daemon):
2020-06-11 19:43:55.944 65884 WARNING oslo.privsep.daemon [-] privsep log: sudo: unable to execute /usr/bin/neutron-rootwrap: Permission denied
2020-06-11 19:43:55.951 65884 CRITICAL oslo.privsep.daemon [-] privsep helper command exited non-zero (1)

Syslog:
Jun 11 19:45:49 centos-8 setroubleshoot[65996]: SELinux is preventing /usr/bin/sudo from execute_no_trans access on the file /usr/bin/neutron-rootwrap.

Audit log:
type=AVC msg=audit(1592206154.561:5419): avc:  denied  { execute_no_trans } for  pid=3827 comm="sudo" path="/usr/bin/neutron-rootwrap-daemon" dev="sda1" ino=9310801 scontext=system_u:system_r:neutron_t:s0 tcontext=system_u:object_r:neutron_exec_t:s0 tclass=file permissive=0
type=AVC msg=audit(1592206157.680:5438): avc:  denied  { execute_no_trans } for  pid=3860 comm="sudo" path="/usr/bin/neutron-rootwrap-daemon" dev="sda1" ino=9310801 scontext=system_u:system_r:neutron_t:s0 tcontext=system_u:object_r:neutron_exec_t:s0 tclass=file permissive=0

Verified that it can spawn the rootwrap helper with these changes:
2020-06-15 07:29:21.985 3880 INFO oslo_rootwrap.client [-] Spawned new rootwrap daemon process with pid=3886