### PR TITLE
Add dac_override capability to neutron_t

### DIFF
--- a/os-neutron.te
+++ b/os-neutron.te
@@ -20,6 +20,7 @@ gen_require(`
 	type nsfs_t;
 	class capability setpcap;
 	class capability setpgid;
+	class capability dac_override;
 	class key_socket { write read create };
 	class netlink_xfrm_socket { bind create nlmsg_write };
 	class process signal;
@@ -62,10 +63,10 @@ allow neutron_t http_port_t:tcp_socket name_bind;
 # Bugzilla 1230900
 manage_sock_files_pattern(neutron_t, neutron_tmp_t, neutron_tmp_t)
 
-# Bugzilla 1245846
+# Bugzilla 1245846 & 1850973
 allow neutron_t ipsec_key_file_t:file { read ioctl open getattr };
 allow neutron_t modules_object_t:file getattr;
-allow neutron_t self:capability setpcap;
+allow neutron_t self:capability { setpcap dac_override };
 allow neutron_t self:key_socket { write read create };
 allow neutron_t self:netlink_xfrm_socket { bind create nlmsg_write };
 ipsec_exec_mgmt(neutron_t)

--- a/tests/bz1850973
+++ b/tests/bz1850973
@@ -1,0 +1,1 @@
+type=AVC msg=audit(1593076023.722:2752): avc: denied { dac_override } for pid=91081 comm="privsep-helper" capability=1 scontext=system_u:system_r:neutron_t:s0 tcontext=system_u:system_r:neutron_t:s0 tclass=capability permissive=0


### PR DESCRIPTION
The dac_override capability is required when spawning
the privsep-helper. It's spawned by neutron-rootwrap
which in itself is executed by sudo.

type=AVC msg=audit(1593076023.722:2752): avc:  denied  { dac_override } for  pid=91081 comm="privsep-helper" capability=1  scontext=system_u:system_r:neutron_t:s0 tcontext=system_u:system_r:neutron_t:s0 tclass=capability permissive=0

audit2allow in permissive mode gives the following
$ausearch -c privsep | audit2allow
#============= neutron_t ==============
allow neutron_t self:capability dac_override;