### PR TITLE
local_settings.sh.in: add container_file_t context to /var/lib/tripleo-config

### DIFF
--- a/local_settings.sh.in
+++ b/local_settings.sh.in
@@ -87,6 +87,7 @@ set_file_contexts()
 	fcontext -N -$1 -t httpd_log_t $LOCALSTATEDIR/log/zaqar/zaqar.log
 	fcontext -N -$1 -t container_file_t \"$LOCALSTATEDIR/log/containers(/.*)?\"
 	fcontext -N -$1 -t container_file_t \"$LOCALSTATEDIR/lib/config-data(/.*)?\"
+	fcontext -N -$1 -t container_file_t \"$LOCALSTATEDIR/lib/tripleo-config(/.*)?\"
 	fcontext -N -$1 -t neutron_exec_t $BINDIR/neutron-rootwrap-daemon
 	fcontext -N -$1 -t neutron_exec_t $BINDIR/neutron-vpn-agent
 	fcontext -N -$1 -t swift_var_cache_t \"$LOCALSTATEDIR/cache/swift(/.*)\"


### PR DESCRIPTION
We have been managing the container_file_t context for
/var/lib/tripleo-config directory via Ansible until now; but this is an
expensive and risky operation as we rely on another framework.

It would be much simpler for to just use openstack-selinux like we
already do for other directories (e.g. /var/lib/config-data); so this
patch aims to do it.

/var/lib/tripleo-config is a directory which contains tripleo containers
configuration files and it needs this context to operate when SElinux is
enforcing.