### PR TITLE
dnsmasq_t needs dac_override

### DIFF
--- a/os-dnsmasq.te
+++ b/os-dnsmasq.te
@@ -4,9 +4,14 @@ gen_require(`
 	type var_lib_t;
 	type dnsmasq_t;
 	class file manage_file_perms;
+	class capability dac_override;
 ')
 
 # bug 1568993
 # dnsmasq_t can already create/delete var_lib_t directories
 allow dnsmasq_t var_lib_t:file manage_file_perms;
 
+gen_tunable(os_dnsmasq_dac_override, false)
+tunable_policy(`os_dnsmasq_dac_override',`
+	allow dnsmasq_t self:capability { dac_override };
+')


### PR DESCRIPTION
Another annoying issue like this, from what I can see the only change that is done is that the dnsmasq process is spawned by the dnsmasq user and not nobody.

This is the error I get:
```
2020-06-26 13:22:39.613 22585 ERROR neutron.agent.linux.utils [req-cb072d83-f3a5-45ce-b525-7d1831212c24 - - - - -] Exit code: 3; Stdin: ; Stdout: ; Stderr:
dnsmasq: cannot open or create lease file /var/lib/neutron/dhcp/3502745e-b961-480e-acc8-1a382abb787e/leases: Permission denied
```

The audit log:
```
type=AVC msg=audit(1593170567.330:1439): avc:  denied  { dac_override } for  pid=45072 comm="dnsmasq" capability=1  scontext=system_u:system_r:dnsmasq_t:s0 tcontext=system_u:system_r:dnsmasq_t:s0 tclass=capability permissive=0
```

```
$ ausearch -m avc | audit2allow
#============= dnsmasq_t ==============
allow dnsmasq_t self:capability dac_override;
```

From CentOS 7 node (working):
```
$ ls -ldZ /var/lib/neutron/
drwxr-xr-x. neutron neutron system_u:object_r:neutron_var_lib_t:s0 /var/lib/neutron/

$ ls -ldZ /var/lib/neutron/dhcp/
drwxr-xr-x. neutron neutron system_u:object_r:neutron_var_lib_t:s0 /var/lib/neutron/dhcp/

$ ls -lZ /var/lib/neutron/dhcp/*/leases
-rw-r--r--. neutron neutron system_u:object_r:neutron_var_lib_t:s0 /var/lib/neutron/dhcp/116fd367-4400-4a0c-b3cd-0c0473869f62/leases

$ ps auxZ | grep dnsmasq
system_u:system_r:dnsmasq_t:s0  nobody   3669907  0.1  0.0  53900  1140 ?        S    Jun24   3:49 dnsmasq --no-hosts --no-resolv --pid-file=/var/lib/neutron/dhcp/116fd367-4400-4a0c-b3cd-0c0473869f62/pid --dhcp-hostsfile=/var/lib/neutron/dhcp/116fd367-4400-4a0c-b3cd-0c0473869f62/host --addn-hosts=/var/lib/neutron/dhcp/116fd367-4400-4a0c-b3cd-0c0473869f62/addn_hosts --dhcp-optsfile=/var/lib/neutron/dhcp/116fd367-4400-4a0c-b3cd-0c0473869f62/opts --dhcp-leasefile=/var/lib/neutron/dhcp/116fd367-4400-4a0c-b3cd-0c0473869f62/leases --dhcp-match=set:ipxe,175 --dhcp-userclass=set:ipxe6,iPXE --local-service --bind-dynamic --dhcp-range=set:subnet-cc186a14-4d4b-4747-992b-37c525760d5d,10.10.0.0,static,255.255.255.0,86400s --dhcp-option-force=option:mtu,1450 --dhcp-lease-max=256 --conf-file= --domain=openstacklocal
```

From CentOS 8 node (only working with SELinux set to permissive without this patch):
```
$ ls -ldZ /var/lib/neutron/
drwxr-xr-x. 7 neutron neutron system_u:object_r:neutron_var_lib_t:s0 140 Jun 26 13:22 /var/lib/neutron/

$ ls -ldZ /var/lib/neutron/dhcp/
drwxr-xr-x. 12 neutron neutron system_u:object_r:neutron_var_lib_t:s0 4096 Jun 26 13:22 /var/lib/neutron/dhcp/

$ ls -lZ /var/lib/neutron/dhcp/*/leases
-rw-r--r--. 1 neutron neutron system_u:object_r:neutron_var_lib_t:s0 170 Jun 26 13:22 /var/lib/neutron/dhcp/116fd367-4400-4a0c-b3cd-0c0473869f62/leases

$ ps auxZ | grep dnsmasq
system_u:system_r:dnsmasq_t:s0  dnsmasq    45381  0.0  0.0  71960  2360 ?        S    13:22   0:00 dnsmasq --no-hosts --no-resolv --pid-file=/var/lib/neutron/dhcp/116fd367-4400-4a0c-b3cd-0c0473869f62/pid --dhcp-hostsfile=/var/lib/neutron/dhcp/116fd367-4400-4a0c-b3cd-0c0473869f62/host --addn-hosts=/var/lib/neutron/dhcp/116fd367-4400-4a0c-b3cd-0c0473869f62/addn_hosts --dhcp-optsfile=/var/lib/neutron/dhcp/116fd367-4400-4a0c-b3cd-0c0473869f62/opts --dhcp-leasefile=/var/lib/neutron/dhcp/116fd367-4400-4a0c-b3cd-0c0473869f62/leases --dhcp-match=set:ipxe,175 --dhcp-userclass=set:ipxe6,iPXE --local-service --bind-dynamic --dhcp-range=set:subnet-cc186a14-4d4b-4747-992b-37c525760d5d,10.10.0.0,static,255.255.255.0,86400s --dhcp-option-force=option:mtu,1450 --dhcp-lease-max=256 --conf-file= --domain=openstacklocal
```