### PR TITLE
os-redis: allow init_t to unlink socket files

### DIFF
--- a/os-redis.te
+++ b/os-redis.te
@@ -1,6 +1,8 @@
 policy_module(os-redis,0.1)
 
 gen_require(`
+	type container_file_t;
+	type init_t;
 	type redis_port_t;
 	type redis_t;
 	type cluster_var_log_t;
@@ -8,8 +10,11 @@ gen_require(`
 	type useradd_t;
 	class tcp_socket name_connect;
 	class file { read write };
+	class sock_file { setattr unlink };
 ')
 
 # Bugzilla 1283674
 allow sshd_t cluster_var_log_t:file { read write };
 allow useradd_t cluster_var_log_t:file { read write };
+# Bugzilla 1860423
+allow init_t container_file_t:sock_file { setattr unlink };

--- a/tests/bz1860423
+++ b/tests/bz1860423
@@ -1,0 +1,1 @@
+type=AVC msg=audit(1595596546.420:1482): avc:  denied  { unlink } for  pid=1 comm="systemd" name="redis.sock" dev="tmpfs" ino=419874 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:container_file_t:s0 tclass=sock_file permissive=0


### PR DESCRIPTION
Redis has a socket file in /run/redis/redis.sock and when the service
restarts, the init_t type needs to be able to unlink a socket file.

Resolves rhbz#1860423