### PR TITLE
Allow unmount for fs_t to neutron

### DIFF
--- a/os-neutron.te
+++ b/os-neutron.te
@@ -18,6 +18,7 @@ gen_require(`
 	type keepalived_t;
 	type logrotate_t;
 	type nsfs_t;
+	type fs_t;
 	class capability setpcap;
 	class capability setpgid;
 	class capability dac_override;
@@ -117,6 +118,9 @@ tunable_policy(`os_neutron_use_execmem',`
 
 # Bugzilla 1419418
 allow neutron_t nsfs_t:file { open read };
+
+# Bugzilla 1893132
+allow neutron_t fs_t:filesystem unmount;
 
 # Bugzilla 1547197
 allow neutron_t self:process setpgid;

--- a/tests/bz1893132
+++ b/tests/bz1893132
@@ -1,0 +1,2 @@
+type=AVC msg=audit(1604010639.062:643445): avc: denied { unmount } for pid=753263 comm="privsep-helper" scontext=system_u:system_r:neutron_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem
+type=AVC msg=audit(1604010639.098:643446): avc: denied { unmount } for pid=753263 comm="privsep-helper" scontext=system_u:system_r:neutron_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem


### PR DESCRIPTION
The DHCP agent fails on CentOS 8 with a
the standard 4.18 kernel.

The error from neutron-dhcp-agent:
2020-10-29 03:49:45.311 289412 ERROR neutron.agent.dhcp.agent [req-b3b5807e-c3de-4a7d-98a1-d1a067c9dba7 - - - - -] Unable to disable dhcp for db4a4385-2e44-44a3-a002-754cc2b44ae2.: OSError: [Errno 16] Device or resource busy
2020-10-29 03:49:45.311 289412 ERROR neutron.agent.dhcp.agent Traceback (most recent call last):
2020-10-29 03:49:45.311 289412 ERROR neutron.agent.dhcp.agent   File "/usr/lib/python3.6/site-packages/neutron/agent/dhcp/agent.py", line 161, in call_driver
2020-10-29 03:49:45.311 289412 ERROR neutron.agent.dhcp.agent     getattr(driver, action)(**action_kwargs)
2020-10-29 03:49:45.311 289412 ERROR neutron.agent.dhcp.agent   File "/usr/lib/python3.6/site-packages/neutron/agent/linux/dhcp.py", line 255, in disable
2020-10-29 03:49:45.311 289412 ERROR neutron.agent.dhcp.agent     self._destroy_namespace_and_port()
2020-10-29 03:49:45.311 289412 ERROR neutron.agent.dhcp.agent   File "/usr/lib/python3.6/site-packages/neutron/agent/linux/dhcp.py", line 266, in _destroy_namespace_and_port
2020-10-29 03:49:45.311 289412 ERROR neutron.agent.dhcp.agent     ip_lib.delete_network_namespace(self.network.namespace)
2020-10-29 03:49:45.311 289412 ERROR neutron.agent.dhcp.agent   File "/usr/lib/python3.6/site-packages/neutron/agent/linux/ip_lib.py", line 913, in delete_network_namespace
2020-10-29 03:49:45.311 289412 ERROR neutron.agent.dhcp.agent     privileged.remove_netns(namespace, **kwargs)
2020-10-29 03:49:45.311 289412 ERROR neutron.agent.dhcp.agent   File "/usr/lib/python3.6/site-packages/oslo_privsep/priv_context.py", line 245, in _wrap
2020-10-29 03:49:45.311 289412 ERROR neutron.agent.dhcp.agent     return self.channel.remote_call(name, args, kwargs)
2020-10-29 03:49:45.311 289412 ERROR neutron.agent.dhcp.agent   File "/usr/lib/python3.6/site-packages/oslo_privsep/daemon.py", line 204, in remote_call
2020-10-29 03:49:45.311 289412 ERROR neutron.agent.dhcp.agent     raise exc_type(*result[2])
2020-10-29 03:49:45.311 289412 ERROR neutron.agent.dhcp.agent OSError: [Errno 16] Device or resource busy

The error from audit log:
type=AVC msg=audit(1604010639.062:643445): avc:  denied  { unmount } for  pid=753263 comm="privsep-helper" scontext=system_u:system_r:neutron_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=0
type=AVC msg=audit(1604010639.098:643446): avc:  denied  { unmount } for  pid=753263 comm="privsep-helper" scontext=system_u:system_r:neutron_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=0
type=AVC msg=audit(1604010639.922:643449): avc:  denied  { unmount } for  pid=753263 comm="privsep-helper" scontext=system_u:system_r:neutron_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=1

type=PATH msg=audit(1604010640.165:684660): item=0 name="/var/run/netns/qdhcp-db4a4385-2e44-44a3-a002-754cc2b44ae2" inode=4026533623 dev=00:03 mode=0100444 ouid=0 ogid=0 rdev=00:00 obj=system_u:system_r:neutron_t:s0 nametype=NORMAL cap_fe=? cap_fver=? cap_fp=? cap_fi=?OUID="root" OGID="root"
type=AVC msg=audit(1604010640.203:684661): avc:  denied  { unmount } for  pid=932089 comm="privsep-helper" scontext=system_u:system_r:neutron_t:s0 tcontext=system_u:object_r:fs_t:s0 tclass=filesystem permissive=0
type=SYSCALL msg=audit(1604010640.203:684661): arch=c000003e syscall=166 success=no exit=-13 a0=7fa614972290 a1=2 a2=7fa61d7d0000 a3=7fa6147f9120 items=1 ppid=1 pid=932089 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="privsep-helper" exe="/usr/libexec/platform-python3.6" subj=system_u:system_r:neutron_t:s0 key=(null)ARCH=x86_64 SYSCALL=umount2 AUID="unset" UID="root" GID="root" EUID="root" SUID="root" FSUID="root" EGID="root" SGID="root" FSGID="root"
