### PR TITLE
Allow container domains to send sigchld to container runtime

### DIFF
--- a/os-podman.te
+++ b/os-podman.te
@@ -1,5 +1,7 @@
 policy_module(os-podman, 1.0)
 gen_require(`
+        attribute container_domain;
+        attribute container_runtime_domain;
         type container_t;
         type container_file_t;
         type openvswitch_t;
@@ -31,3 +33,6 @@ manage_dirs_pattern(container_t, cluster_var_log_t, cluster_var_log_t);
 
 # Needed for LP#1853652
 allow init_t container_file_t:file { execute execute_no_trans };
+
+# Bugzilla 1926765. See also container-selinux commit 448dfb
+allow container_domain container_runtime_domain:process sigchld;

--- a/tests/bz1926765
+++ b/tests/bz1926765
@@ -1,0 +1,1 @@
+type=AVC msg=audit(1612971631.581:8655): avc:  denied  { sigchld } for  pid=236718 comm="conmon" scontext=system_u:system_r:container_t:s0:c409,c785 tcontext=unconfined_u:system_r:container_runtime_t:s0 tclass=process permissive=1


### PR DESCRIPTION
This is resolved in later versions of container-selinux. We're adding the rule to openstack-selinux for environments where it's not currently possible to install a more recent version of the container-selinux package.

Resolves: rhbz#1926765