### PR TITLE
Allow neutron_t to SIGTERM haproxy owned processes

### DIFF
--- a/os-neutron.te
+++ b/os-neutron.te
@@ -105,8 +105,8 @@ optional_policy(`
 	# Bugzilla 1114254
 	manage_files_pattern(haproxy_t, neutron_var_lib_t, neutron_var_lib_t)
 	manage_sock_files_pattern(haproxy_t, neutron_var_lib_t, neutron_var_lib_t)
-	# Bugzilla 1115724
-	allow neutron_t haproxy_t:process sigkill;
+	# Bugzilla 1115724 and 1962802
+	allow neutron_t haproxy_t:process { sigkill signal };
 	allow neutron_t proc_t:filesystem unmount;
 ')
 

--- a/tests/bz1962802
+++ b/tests/bz1962802
@@ -1,0 +1,1 @@
+type=AVC msg=audit(1621521322.324:1212399): avc:  denied  { signal } for  pid=1442393 comm="kill" scontext=system_u:system_r:neutron_t:s0 tcontext=system_u:system_r:haproxy_t:s0 tclass=process permissive=1


### PR DESCRIPTION
Neutron needs to be able to not just send SIGKILL
to processes but also SIGTERM for graceful shutdown
and in some parts SIGHUP for process reloading.