### PR TITLE
Allow neutron-keepalived-state-change cache_home_t

### DIFF
--- a/os-neutron.te
+++ b/os-neutron.te
@@ -19,6 +19,7 @@ gen_require(`
 	type logrotate_t;
 	type nsfs_t;
 	type fs_t;
+	type cache_home_t;
 	class capability setpcap;
 	class capability setpgid;
 	class capability dac_override;
@@ -118,6 +119,8 @@ tunable_policy(`os_neutron_use_execmem',`
 
 # Bugzilla 1419418
 allow neutron_t nsfs_t:file { open read };
+
+allow neutron_t cache_home_t:file { open read write };
 
 # Bugzilla 1893132
 allow neutron_t fs_t:filesystem unmount;


### PR DESCRIPTION
The neutron-keepalived-state-change process is
started by the neutron-l3-agent and running as root.

It in turn is using stevedore [1] to load drivers
that has a cache mechanism trying to write to
~/.cache/python-entrypoints by default [2].

This adds a allow for neutron_t processes to access
cache_home_t (~/.cache) that is the default for
stevedore.

This doesn't cause any issues per se since stevedore
passes any IOError on write and just continues so
this is up to our discretion to allow.

[1] https://pypi.org/project/stevedore/
[2] https://github.com/openstack/stevedore/blob/master/stevedore/_cache.py#L47