### PR TITLE
Move the dac_override rules behind booleans.

### DIFF
--- a/local_settings.sh.in
+++ b/local_settings.sh.in
@@ -254,7 +254,13 @@ install_policies() {
 	boolean -N -m --on os_gnocchi_use_nfs
 	boolean -N -m --on os_virtlogd_use_nfs
 	boolean -N -m --on os_glance_use_nfs
-	boolean -N -m --on os_cinder_use_nfs"
+	boolean -N -m --on os_cinder_use_nfs
+	boolean -N -m --on os_glance_dac_override
+	boolean -N -m --on os_haproxy_dac_override
+	boolean -N -m --on os_keepalived_dac_override
+	boolean -N -m --on os_openvswitch_dac_override
+	boolean -N -m --on os_virtlog_dac_override"
+	# Note the last 5 dac_override booleans will be eventually disabled (bugzilla 2000945)
 
 	do_echo "Setting OpenStack booleans..."
 	echo "$INPUT" | $SBINDIR/semanage import -N

--- a/os-glance.te
+++ b/os-glance.te
@@ -73,10 +73,15 @@ tunable_policy(`os_glance_use_sudo',`
 	allow glance_api_t fixed_disk_device_t:blk_file { getattr ioctl open read setattr write };
 	allow glance_api_t init_t:file { getattr open read };
 	allow glance_api_t self:capability { setuid setgid };
-	allow glance_api_t self:capability { audit_write setuid setgid chown dac_override sys_rawio sys_resource };
+	allow glance_api_t self:capability { audit_write setuid setgid chown sys_rawio sys_resource };
 	allow glance_api_t self:netlink_audit_socket { create nlmsg_relay };
 	allow glance_api_t self:process { setcap setrlimit setsched };
 	allow glance_api_t sysfs_t:file append;
+')
+
+gen_tunable(os_glance_dac_override, false)
+tunable_policy(`os_glance_dac_override',`
+	allow glance_api_t self:capability dac_override;
 ')
 
 # Bugzilla 1653640

--- a/os-keepalived.te
+++ b/os-keepalived.te
@@ -34,8 +34,13 @@ allow keepalived_t init_var_lib_t:file { read getattr open };
 allow keepalived_t var_lib_t:file { read getattr open };
 allow keepalived_t var_log_t:file open;
 # bz1434826 - sys_admin
-allow keepalived_t self:capability { dac_override sys_admin };
+allow keepalived_t self:capability { sys_admin };
 allow keepalived_t neutron_t:process sigkill;
+
+gen_tunable(os_keepalived_dac_override, false)
+tunable_policy(`os_keepalived_dac_override',`
+	allow keepalived_t self:capability dac_override;
+')
 
 # Bugzilla 1206148
 allow keepalived_t sysfs_t:filesystem getattr;

--- a/os-nova.te
+++ b/os-nova.te
@@ -69,7 +69,10 @@ allow httpd_t nova_log_t:file { open create };
 nova_manage_lib_files(virtlogd_t)
 
 # Bugzilla 1377272
-allow virtlogd_t self:capability dac_override;
+gen_tunable(os_virtlog_dac_override, false)
+tunable_policy(`os_virtlog_dac_override',`
+        allow virtlogd_t self:capability dac_override;
+')
 
 # Bugzilla #1499800 (workaround)
 # src: https://eucalyptus.atlassian.net/browse/EUCA-13447

--- a/os-octavia.te
+++ b/os-octavia.te
@@ -72,7 +72,12 @@ allow haproxy_t unconfined_service_t:file { open read };
 allow haproxy_t var_lib_t:dir { add_name write remove_name };
 allow haproxy_t var_lib_t:file { create execute execute_no_trans getattr ioctl open read write unlink };
 allow haproxy_t var_lib_t:sock_file { create link rename setattr unlink write };
-allow haproxy_t self:capability { sys_admin dac_override };
+allow haproxy_t self:capability { sys_admin };
+
+gen_tunable(os_haproxy_dac_override, false)
+tunable_policy(`os_haproxy_dac_override',`
+        allow haproxy_t self:capability dac_override;
+')
 
 # These are needed during boot when setting up the netns
 allow haproxy_t etc_t:dir mounton;

--- a/os-ovs.te
+++ b/os-ovs.te
@@ -110,8 +110,13 @@ dontaudit openvswitch_t neutron_t:file { read open getattr };
 corenet_tcp_connect_all_ports(openvswitch_t)
 
 # #1498797
-allow openvswitch_t self:capability { audit_write dac_override };
+allow openvswitch_t self:capability { audit_write };
 allow openvswitch_t self:netlink_audit_socket { create nlmsg_relay read write };
+
+gen_tunable(os_openvswitch_dac_override, false)
+tunable_policy(`os_openvswitch_dac_override',`
+	allow openvswitch_t self:capability dac_override;
+')
 
 # #1542107
 allow openvswitch_t svirt_tmpfs_t:file { read write };


### PR DESCRIPTION
As a preparation step for bug 2000945 which aims to reduce dac_override
usage, move the remaining dac_override rules behind booleans.

This patch is currently a noop as the booleans are then enabled. The
end goal is to disable them all once the code fixes are ready and
merged.

Related to rhbz#2000945.