### PR TITLE
Allow container_t to read cert_t context

### DIFF
--- a/os-podman.te
+++ b/os-podman.te
@@ -2,6 +2,7 @@ policy_module(os-podman, 1.0)
 gen_require(`
         attribute container_domain;
         attribute container_runtime_domain;
+        type cert_t;
         type container_t;
         type container_file_t;
         type openvswitch_t;
@@ -41,3 +42,6 @@ allow container_domain container_runtime_domain:process sigchld;
 # Bugzilla 1941922 + 1941412
 manage_files_pattern(container_t, swift_data_t, swift_data_t);
 manage_dirs_pattern(container_t, swift_data_t, swift_data_t);
+
+# Discovered while working with CS9 and latest podman/SELinux
+read_files_pattern(container_t, cert_t, cert_t)

--- a/tests/cs9_cert_t
+++ b/tests/cs9_cert_t
@@ -1,0 +1,1 @@
+type=AVC msg=audit(1631177895.318:10745): avc:  denied  { read } for  pid=40184 comm="python3" name="mysql.key" dev="vda2" ino=819659 scontext=system_u:system_r:container_t:s0:c499,c848 tcontext=system_u:object_r:cert_t:s0 tclass=file permissive=0


### PR DESCRIPTION
This is a "regression" compared to earlier versions of
podman/container-selinux: in container-tools:3.0 (as provided by cs8),
container_t was allowed to access cert_t - this isn't the case anymore
with container-tools:latest as provided by cs9.

This patch ensures bind-mounts such as
/etc/pki/tls/private/overcloud_endpoint.pem:/etc/pki/tls/private/...:ro
are still working in future releases of TripleO/OSP.