### PR TITLE
Allow container_t to read fixed_disk_device_t

### DIFF
--- a/os-podman.te
+++ b/os-podman.te
@@ -9,6 +9,8 @@ gen_require(`
         type cluster_var_log_t;
         type init_t;
         type swift_data_t;
+        type fixed_disk_device_t;
+        class blk_file getattr;
 ')
 #============= container_t ==============
 miscfiles_read_generic_certs(container_t)
@@ -41,3 +43,6 @@ allow container_domain container_runtime_domain:process sigchld;
 # Bugzilla 1941922 + 1941412
 manage_files_pattern(container_t, swift_data_t, swift_data_t);
 manage_dirs_pattern(container_t, swift_data_t, swift_data_t);
+
+# LP 1944539
+allow container_t fixed_disk_device_t:blk_file getattr;

--- a/tests/lp1944539
+++ b/tests/lp1944539
@@ -1,0 +1,1 @@
+type=AVC msg=audit(09/22/2021 10:46:27.412:11298) : avc:  denied  { getattr } for  pid=338462 comm=lsof path=/dev/sda2 dev="devtmpfs" ino=24765 scontext=system_u:system_r:container_t:s0:c216,c474 tcontext=system_u:object_r:fixed_disk_device_t:s0 tclass=blk_file permissive=1


### PR DESCRIPTION
This is needed for container healthchecks based on `lsof' command.