### PR TITLE
Allow spawning instances with vTPM driver

### DIFF
--- a/os-virt.te
+++ b/os-virt.te
@@ -1,6 +1,7 @@
 policy_module(os-virt,0.1)
 
 gen_require(`
+	type container_file_t;
 	type systemd_logind_t;
 	type systemd_logind_inhibit_var_run_t;
 	type virtlogd_t;
@@ -33,3 +34,9 @@ allow svirt_t spc_t:tun_socket attach_queue;
 
 # Bugzilla 1751300
 allow spc_t unlabeled_t:key manage_key_perms;
+
+# Bugzilla 2007314
+gen_tunable(os_enable_vtpm, false)
+tunable_policy(`os_enable_vtpm',`
+        manage_sock_files_pattern(svirt_t, container_file_t, container_file_t)
+')


### PR DESCRIPTION
Add a boolean to enable rules related to vTPM features

Because the boolean is disabled by default, the tests can't be stored in-repo. Including the denials in the commit message instead.

type=AVC msg=audit(1632409882.991:1060759): avc:  denied  { create } for  pid=1039169 comm="swtpm" name="9-instance-00000009-swtpm.sock" scontext=system_u:system_r:svirt_t:s0:c50,c343 tcontext=system_u:object_r:container_file_t:s0 tclass=sock_file permissive=1
type=AVC msg=audit(1632409882.991:1060760): avc:  denied  { setattr } for  pid=1039169 comm="swtpm" name="9-instance-00000009-swtpm.sock" dev="tmpfs" ino=1100774 scontext=system_u:system_r:svirt_t:s0:c50,c343 tcontext=system_u:object_r:container_file_t:s0 tclass=sock_file permissive=1

Related-Bug: rhbz#2007314