### PR TITLE
Allow container_t to manage Swift cache files

### DIFF
--- a/os-podman.te
+++ b/os-podman.te
@@ -9,6 +9,7 @@ gen_require(`
         type cluster_var_log_t;
         type init_t;
         type swift_data_t;
+        type swift_var_cache_t;
         type fixed_disk_device_t;
         class blk_file getattr;
 ')
@@ -43,6 +44,9 @@ allow container_domain container_runtime_domain:process sigchld;
 # Bugzilla 1941922 + 1941412
 manage_files_pattern(container_t, swift_data_t, swift_data_t);
 manage_dirs_pattern(container_t, swift_data_t, swift_data_t);
+# Bugzilla 2013194
+manage_files_pattern(container_t, swift_var_cache_t, swift_var_cache_t);
+manage_dirs_pattern(container_t, swift_var_cache_t, swift_var_cache_t);
 
 # LP 1944539
 allow container_t fixed_disk_device_t:blk_file getattr;

--- a/tests/bz2013194
+++ b/tests/bz2013194
@@ -1,0 +1,1 @@
+type=AVC msg=audit(1633990096.040:24220): avc:  denied  { read write } for  pid=5337 comm="swift-container" name="container.recon" dev="vda2" ino=46373631 scontext=system_u:system_r:container_t:s0:c50,c57 tcontext=system_u:object_r:swift_var_cache_t:s0 tclass=file permissive=0


### PR DESCRIPTION
Similarly to the issue described in commit d1e3cb, in some cases when a
problem occurs during an update and interrupts it, the Swift data/cache
files may end up incorrectly labelled. With these new rules, the update
can be resumed properly.

Resolves: rhbz#2013194