### PR TITLE
Allow container_t to manage container_log_t files

### DIFF
--- a/local_settings.sh.in
+++ b/local_settings.sh.in
@@ -28,7 +28,6 @@ declare -A custom_fcontext=(
 ["$LOCALSTATEDIR/log/ceilometer/app.log"]='httpd_log_t'
 ["$LOCALSTATEDIR/log/panko/app.log"]='httpd_log_t'
 ["$LOCALSTATEDIR/log/zaqar/zaqar.log"]='httpd_log_t'
-["$LOCALSTATEDIR/log/containers(/.*)?"]='container_file_t'
 ["$LOCALSTATEDIR/lib/config-data(/.*)?"]='container_file_t'
 ["$LOCALSTATEDIR/lib/kolla(/.*)?"]='container_file_t'
 ["$LOCALSTATEDIR/lib/tripleo-config(/.*)?"]='container_file_t'

--- a/os-podman.te
+++ b/os-podman.te
@@ -4,6 +4,7 @@ gen_require(`
         attribute container_runtime_domain;
         type container_t;
         type container_file_t;
+        type container_log_t;
         type openvswitch_t;
         type puppet_etc_t;
         type cluster_var_log_t;
@@ -50,3 +51,7 @@ manage_dirs_pattern(container_t, swift_var_cache_t, swift_var_cache_t);
 
 # LP 1944539
 allow container_t fixed_disk_device_t:blk_file getattr;
+
+# Bugzilla 2020210
+manage_files_pattern(container_t, container_log_t, container_log_t);
+manage_dirs_pattern(container_t, container_log_t, container_log_t);

--- a/tests/bz2020210
+++ b/tests/bz2020210
@@ -1,0 +1,1 @@
+type=AVC msg=audit(1635988536.870:9187): avc:  denied  { append } for  pid=128557 comm="redis-server" name="redis.log" dev="vda2" ino=67368647 scontext=system_u:system_r:container_t:s0:c67,c288 tcontext=system_u:object_r:container_log_t:s0 tclass=file permissive=0


### PR DESCRIPTION
A new patch in container-selinux[1] adds a new fcontext for
/var/log/containers, setting it as "container_log_t".

Since this specific rule is set at the system level, we can't remove
nor override it.

While we could ensure every container are mounting this location with
the ":z" flag, leading to a relabelling, it's easier and better to just
allow container_t to manage files with this context.

Therefore, this patch does three things:
- allow container_t on container_log_t for files and directories
- allow logrotate_t on container_log_t for files and directories
- remove the specific fcontext for /var/log/containers location

Note: the "test" log is from an enforcing environment, but we can deduce
that other file management related capabilities (create, unlink and so
on) are also needed, since it's a log location.

[1] https://github.com/containers/container-selinux/commit/7e5f3cae10e2d805821fb84dff7418b9e3b0cc1f