### PR TITLE
[WIP] Swift: Fix access to recon files

### DIFF
--- a/os-swift.te
+++ b/os-swift.te
@@ -3,6 +3,7 @@ policy_module(os-swift,0.1)
 gen_require(`
 	type swift_t;
 	type swift_data_t;
+	type swift_var_cache_t;
 	type amqp_port_t;
 	type var_log_t;
 	class tcp_socket name_connect;
@@ -24,3 +25,6 @@ tunable_policy(`os_swift_use_execmem',`
 
 # Bugzilla 1652297
 allow swift_t swift_data_t:lnk_file { create read };
+
+# Bugzilla 2050636
+allow swift_t swift_var_cache_t:file { create read };


### PR DESCRIPTION
We've seen bunch of selinux denials from swift-container-replicator to
its recon data file, /var/cache/swift/container.recon when swift-
container-sharder is enabled.

This ensures swift processes have access allowed to the recon data
files to avoid such denials.

Resolves: rhbz#2050636