### PR TITLE
Neutron: Fix denied network namespace operations in CentOS 9

### DIFF
--- a/os-neutron.te
+++ b/os-neutron.te
@@ -116,11 +116,14 @@ tunable_policy(`os_neutron_use_execmem',`
 	allow neutron_t self:process execmem;
 ')
 
-# Bugzilla 1419418
-allow neutron_t nsfs_t:file { open read };
+# Bugzilla 1419418 and 2053852
+allow neutron_t nsfs_t:file { open read getattr };
 
 # Bugzilla 1893132
 allow neutron_t fs_t:filesystem unmount;
+
+# Bugzilla 2053852
+allow neutron_t nsfs_t:filesystem unmount;
 
 # Bugzilla 1547197
 allow neutron_t self:process setpgid;

--- a/tests/bz2053852
+++ b/tests/bz2053852
@@ -1,0 +1,2 @@
+type=AVC msg=audit(1644681472.535:9235): avc:  denied  { getattr } for  pid=78599 comm="privsep-helper" path="/run/netns/qdhcp-d6afbd95-bfef-44d7-84cc-559cda9a0686" dev="nsfs" ino=4026532244 scontext=system_u:system_r:neutron_t:s0 tcontext=system_u:object_r:nsfs_t:s0 tclass=file permissive=1
+type=AVC msg=audit(1644681474.970:9248): avc:  denied  { unmount } for  pid=78610 comm="privsep-helper" scontext=system_u:system_r:neutron_t:s0 tcontext=system_u:object_r:nsfs_t:s0 tclass=filesystem permissive=1


### PR DESCRIPTION
Neutron requires access to network namespaces as it creates and deletes
namespaces for tenant resources.
This change fixes some denials found in functional tests with CentOS 9
Stream and OpenStack service installed by RDO packages.

Resolves: rhbz#2053852