### PR TITLE
RabbitMQ: Allow access to tmpfs

### DIFF
--- a/os-rabbitmq.te
+++ b/os-rabbitmq.te
@@ -10,6 +10,7 @@ gen_require(`
 	type rabbitmq_t;
 	type rabbitmq_var_lib_t;
 	type security_t;
+	type tmpfs_t;
 	class dir { read write };
 	class file { getattr open read write };
 	class passwd passwd;
@@ -32,3 +33,6 @@ allow logrotate_t self:passwd passwd;
 allow logrotate_t proc_net_t:file read;
 allow logrotate_t self:process setrlimit;
 allow rabbitmq_t proc_net_t:file read;
+
+# Bugzilla 2056565
+allow rabbitmq_t tmpfs_t:file { read write execute };

--- a/tests/bz2056565
+++ b/tests/bz2056565
@@ -1,0 +1,2 @@
+type=AVC msg=audit(1645438546.184:3306): avc:  denied  { write } for  pid=27672 comm="beam.smp" name="memfd:vmem" dev="tmpfs" ino=3 scontext=system_u:system_r:rabbitmq_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=1
+type=AVC msg=audit(1645438546.184:3307): avc:  denied  { read execute } for  pid=27672 comm="beam.smp" path=2F6D656D66643A766D656D202864656C6574656429 dev="tmpfs" ino=3 scontext=system_u:system_r:rabbitmq_t:s0 tcontext=system_u:object_r:tmpfs_t:s0 tclass=file permissive=1


### PR DESCRIPTION
Recent RabbitMQ in CentOS 9 RDO repo requires access to tmpfs. This
change ensures that selinux permits that access.

Resolves: rhbz#2056565