### PR TITLE
Revert "Octavia: add new policies for the Amphora VM"

### DIFF
--- a/os-octavia.te
+++ b/os-octavia.te
@@ -20,7 +20,6 @@ gen_require(`
 	type unconfined_service_t;
 	type NetworkManager_t;
 	type tmpfs_t;
-	type shell_exec_t;
 	class sock_file { create link rename setattr unlink write };
 	class capability { sys_ptrace sys_admin };
 	class file { create entrypoint execute execute_no_trans getattr ioctl open read write };
@@ -68,13 +67,12 @@ allow keepalived_t sysfs_t:dir mounton;
 allow keepalived_t tmpfs_t:filesystem unmount;
 
 # Same access for haproxy_t
-allow haproxy_t bin_t:file { entrypoint execute execute_no_trans };
+allow haproxy_t bin_t:file { entrypoint execute };
 allow haproxy_t unconfined_service_t:file { open read };
 allow haproxy_t var_lib_t:dir { add_name write remove_name };
 allow haproxy_t var_lib_t:file { create execute execute_no_trans getattr ioctl open read write unlink };
 allow haproxy_t var_lib_t:sock_file { create link rename setattr unlink write };
 allow haproxy_t self:capability { sys_admin };
-allow haproxy_t shell_exec_t:file { entrypoint execute };
 
 gen_tunable(os_haproxy_dac_override, false)
 tunable_policy(`os_haproxy_dac_override',`

--- a/tests/bz2073491
+++ b/tests/bz2073491
@@ -1,3 +1,0 @@
-type=AVC msg=audit(1649425422.841:194): avc:  denied  { entrypoint } for  pid=5633 comm="(sh)" path="/usr/bin/bash" dev="vda1" ino=4215617 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:object_r:shell_exec_t:s0 tclass=file permissive=0
-type=AVC msg=audit(1649676510.117:101): avc:  denied  { execute } for  pid=5236 comm="sh" path="/usr/bin/bash" dev="vda1" ino=4215617 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:object_r:shell_exec_t:s0 tclass=file permissive=0
-type=AVC msg=audit(1649677973.779:106): avc:  denied  { execute_no_trans } for  pid=5246 comm="sh" path="/usr/bin/socat" dev="vda1" ino=4216601 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:object_r:bin_t:s0 tclass=file permissive=0


### PR DESCRIPTION
Reverts redhat-openstack/openstack-selinux#88

In case of an HAProxy flaw, it would allow to get a remote shell execution, among things. There's a better way to solve the issue, directly in octavia project[1]


[1] https://review.opendev.org/c/openstack/octavia/+/837721