### PR TITLE
Octavia: add new policies for the Amphora

### DIFF
--- a/os-octavia.te
+++ b/os-octavia.te
@@ -20,6 +20,7 @@ gen_require(`
 	type unconfined_service_t;
 	type NetworkManager_t;
 	type tmpfs_t;
+	type nsfs_t;
 	class sock_file { create link rename setattr unlink write };
 	class capability { sys_ptrace sys_admin };
 	class file { create entrypoint execute execute_no_trans getattr ioctl open read write };
@@ -86,6 +87,10 @@ allow haproxy_t sysfs_t:filesystem { mount unmount };
 allow haproxy_t user_tmp_t:dir mounton;
 allow haproxy_t NetworkManager_t:file { open read };
 allow haproxy_t sysfs_t:dir mounton;
+gen_tunable(os_haproxy_enable_nsfs, false)
+tunable_policy(`os_haproxy_enable_nsfs', `
+    allow haproxy_t nsfs_t:file { open read };
+')
 
 kernel_read_fs_sysctls(ifconfig_t)
 


### PR DESCRIPTION
Fix an issue when restarting haproxy in a different network namespace
This new exception is enabled by the os_octavia_enable_nsfs boolean.

Resolves: rhbz#2080966