### PR TITLE
Allow to use the multithreading capability in selinux 3.4

### DIFF
--- a/local_settings.sh.in
+++ b/local_settings.sh.in
@@ -10,6 +10,8 @@ DATADIR=${DATADIR:-/usr/share}
 SHAREDSTATEDIR=${SHAREDSTATEDIR:-/var/lib}
 LOCALDIR=${LOCALDIR:-$DATADIR/openstack-selinux/master}
 MODULES=${MODULES:-@MODULES@}
+# libselinux-3.4 introduces a new feature. Let's see if we can use it!
+SELINUX_THREAD_VERSION=3.4
 
 # This is for caching the file modes; -A is a bash associative
 # array ("dict" or "map" in other languages)
@@ -73,6 +75,32 @@ do_echo() {
 	echo $*
 }
 
+# Source : https://stackoverflow.com/questions/4023830/how-to-compare-two-strings-in-dot-separated-version-format-in-bash
+vercomp () {
+	if [[ $1 == $2 ]]; then
+		return 0
+	fi
+	local IFS=.
+	local i ver1=($1) ver2=($2)
+	# fill empty fields in ver1 with zeros
+	for ((i=${#ver1[@]}; i<${#ver2[@]}; i++)); do
+		ver1[i]=0
+	done
+	for ((i=0; i<${#ver1[@]}; i++)); do
+		if [[ -z ${ver2[i]} ]]; then
+			# fill empty fields in ver2 with zeros
+			ver2[i]=0
+		fi
+		if ((10#${ver1[i]} > 10#${ver2[i]})); then
+			return 1
+		fi
+		if ((10#${ver1[i]} < 10#${ver2[i]})); then
+			return 2
+		fi
+	done
+	return 0
+}
+
 function get_clean_name() {
     if [[ "${1}" =~ '(' ]]; then
         echo "$1" | cut -d '(' -f1
@@ -87,6 +115,12 @@ relabel_files() {
     do_echo "Relabeling files..."
     if [ $QUIET -ne 0 ]; then
           opts="-v"
+    fi
+    current_version=$(/usr/bin/secon --version| grep -oE '[0-9]+(\.[0-9]+)+') # ensure we match 3.3, 3.3.1, 3.3-rc3 and so on
+		vercomp $current_version $SELINUX_THREAD_VERSION
+    if [ $? -le 2 ];; then
+      # "-T 0" will use all available cores.
+      opts="${opts} -T 0"
     fi
 
     # Setfiles is a lot like restorecon, except it takes a policy


### PR DESCRIPTION
Starting SELinux 3.4[1], a new "-T <nbthreads>" has been added to some
of the commands related to file management, such as restorecon, setfiles
and fixfiles.
Setting "-T 0" will allow the command to spawn threads matching the
amount of available cores, hopefully making the whole thing faster
(while a bit more I/O intensive).

[1] https://github.com/SELinuxProject/selinux/releases/tag/3.4