### PR TITLE
Use stderr for error in verification function

### DIFF
--- a/local_settings.sh.in
+++ b/local_settings.sh.in
@@ -323,12 +323,16 @@ verify_policies() {
 				break
 			fi
 		done
-		test ${local_failed} -ne 0 && echo "Missing ${module}!"
+		test ${local_failed} -ne 0 && (echo "Missing ${module}!" >&2)
 		let "failed_count+=$local_failed"
 	done
-	echo "Found ${failed_count} missing module(s)."
-	test ${failed_count} -eq 0
-	exit $?
+	if [ ${failed_count} -eq 0 ]; then
+		echo "All modules are present."
+		exit 0
+	else
+		echo "Found ${failed_count} missing module(s)." >&2
+		exit 1
+	fi
 }
 
 


### PR DESCRIPTION
`rpm -V' filters the output and displays only stderr content, so we'd be
missing the important bits of the verification.

With this patch in, the command outputs the list of missing modules, the
amount of them, and the final, default rpm verification failure message.

This patch is a follow-up of
https://github.com/redhat-openstack/openstack-selinux/pull/93