### PR TITLE
Add new boolean os_haproxy_ping for Octavia amphora

### DIFF
--- a/os-octavia.te
+++ b/os-octavia.te
@@ -21,6 +21,8 @@ gen_require(`
 	type NetworkManager_t;
 	type tmpfs_t;
 	type nsfs_t;
+	type shell_exec_t;
+	type ping_exec_t;
 	class sock_file { create link rename setattr unlink write };
 	class capability { sys_ptrace sys_admin };
 	class file { create entrypoint execute execute_no_trans getattr ioctl open read write };
@@ -90,6 +92,14 @@ allow haproxy_t sysfs_t:dir mounton;
 gen_tunable(os_haproxy_enable_nsfs, false)
 tunable_policy(`os_haproxy_enable_nsfs', `
     allow haproxy_t nsfs_t:file { open read };
+')
+gen_tunable(os_haproxy_ping, false)
+tunable_policy(`os_haproxy_ping', `
+    allow haproxy_t ping_exec_t:file { execute execute_no_trans open read };
+    allow haproxy_t self:rawip_socket { create getopt setopt write read };
+    allow haproxy_t self:icmp_socket { create getopt setopt write read };
+    allow haproxy_t self:process setcap;
+    allow haproxy_t shell_exec_t:file execute;
 ')
 
 kernel_read_fs_sysctls(ifconfig_t)


### PR DESCRIPTION
Add an os_haproxy_ping boolean that allows calling the ping command
using haproxy external-check (it fixes PING health-monitor in Octavia).

This patch applies to both RHEL8 and Centos 9 Stream.

These exceptions are added based on the audit.log files. They also
includes additional exceptions (read and write for rawip_socket and
icmp_socket) that didn't appear in the logs, but "Permission denied"
error was observed with strace.

Audit logs from rhel 8:

type=AVC msg=audit(1655139472.450:1125): avc:  denied  { execute } for  pid=7167 comm=haproxy name=bash dev=vda1 ino=4215375 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:object_r:shell_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1655139472.452:1126): avc:  denied  { execute } for  pid=7168 comm=ping-wrapper.sh name=ping dev=vda1 ino=4215754 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:object_r:ping_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1655139472.452:1126): avc:  denied  { read open } for  pid=7168 comm=ping-wrapper.sh path=/usr/bin/ping dev=vda1 ino=4215754 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:object_r:ping_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1655139472.452:1126): avc:  denied  { execute_no_trans } for  pid=7168 comm=ping-wrapper.sh path=/usr/bin/ping dev=vda1 ino=4215754 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:object_r:ping_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1655139472.457:1127): avc:  denied  { setcap } for  pid=7168 comm=ping scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:system_r:haproxy_t:s0 tclass=process permissive=1
type=AVC msg=audit(1655139472.457:1128): avc:  denied  { create } for  pid=7168 comm=ping scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:system_r:haproxy_t:s0 tclass=icmp_socket permissive=1
type=AVC msg=audit(1655139472.457:1129): avc:  denied  { create } for  pid=7168 comm=ping scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:system_r:haproxy_t:s0 tclass=rawip_socket permissive=1
type=AVC msg=audit(1655139472.457:1130): avc:  denied  { setopt } for  pid=7168 comm=ping lport=1 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:system_r:haproxy_t:s0 tclass=rawip_socket permissive=1
type=AVC msg=audit(1655139472.457:1131): avc:  denied  { getopt } for  pid=7168 comm=ping lport=1 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:system_r:haproxy_t:s0 tclass=rawip_socket permissive=1
type=AVC msg=audit(1655139496.100:1133): avc:  denied  { execmem } for  pid=7217 comm=haproxy scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:system_r:haproxy_t:s0 tclass=process permissive=1

From centos 9 stream:

type=AVC msg=audit(1657006743.881:191): avc:  denied  { execute } for  pid=1012 comm=haproxy name=bash dev=vda1 ino=21130 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:object_r:shell_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1657006743.885:192): avc:  denied  { execute } for  pid=1013 comm=ping-wrapper.sh name=ping dev=vda1 ino=21697 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:object_r:ping_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1657006743.885:192): avc:  denied  { read open } for  pid=1013 comm=ping-wrapper.sh path=/usr/bin/ping dev=vda1 ino=21697 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:object_r:ping_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1657006743.885:192): avc:  denied  { execute_no_trans } for  pid=1013 comm=ping-wrapper.sh path=/usr/bin/ping dev=vda1 ino=21697 scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:object_r:ping_exec_t:s0 tclass=file permissive=1
type=AVC msg=audit(1657006743.890:193): avc:  denied  { setcap } for  pid=1013 comm=ping scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:system_r:haproxy_t:s0 tclass=process permissive=1
type=AVC msg=audit(1657006743.891:194): avc:  denied  { create } for  pid=1013 comm=ping scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:system_r:haproxy_t:s0 tclass=icmp_socket permissive=1
type=AVC msg=audit(1657006743.891:195): avc:  denied  { setopt } for  pid=1013 comm=ping scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:system_r:haproxy_t:s0 tclass=icmp_socket permissive=1
type=AVC msg=audit(1657006743.891:196): avc:  denied  { getopt } for  pid=1013 comm=ping scontext=system_u:system_r:haproxy_t:s0 tcontext=system_u:system_r:haproxy_t:s0 tclass=icmp_socket permissive=1

Resolves: rhbz#2096387