### PR TITLE
docs: Add container note

### DIFF
--- a/doc/CONTRIBUTING.md
+++ b/doc/CONTRIBUTING.md
@@ -29,7 +29,9 @@ How to run the tests
 
         $ make clean all install check
 
-It is recommended to use a VM for this.
+It is recommended to use a VM for this. Note that it is not usually
+possible nor recommended to develop or test SELinux policies from within
+a container.
 
 Fixing an issue
 ----------------


### PR DESCRIPTION
Modifying SELinux policies on a running system requires access
to kernel. This is usually disabled within containers, so add
a note since we have had questions in the past concerning
containers while debugging SELinux policies.