### PR TITLE
OS specific modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,19 @@
-TARGETS?=os-ovs os-swift os-nova os-neutron os-mysql os-glance os-rsync os-rabbitmq os-keepalived os-keystone os-haproxy os-mongodb os-ipxe os-redis os-cinder os-httpd os-gnocchi os-collectd os-virt os-dnsmasq os-octavia os-podman os-rsyslog os-pbis os-barbican os-logrotate os-certmonger os-timemaster
+include /etc/os-release
+
+# De-quote, if quoted.
+OS_ID=$(shell echo $(ID))
+OS_VER=$(shell echo $(VERSION_ID))
+OS_MAJ=$(shell OS_VER=$(OS_VER) && echo $${OS_VER/.*/})
+
+# RHEL & rebuilds: if we match one of these, we do a version comparison.
+ifneq (,$(findstring $(OS_ID),rhel centos rocky almalinux))
+# If version 9 or greater, add extra targets
+ifeq ($(OS_MAJ),9)
+EXTRA_TARGETS?=os-ovs-el9
+endif # version 9
+endif # RHEL clones
+
+TARGETS?=os-ovs os-swift os-nova os-neutron os-mysql os-glance os-rsync os-rabbitmq os-keepalived os-keystone os-haproxy os-mongodb os-ipxe os-redis os-cinder os-httpd os-gnocchi os-collectd os-virt os-dnsmasq os-octavia os-podman os-rsyslog os-pbis os-barbican os-logrotate os-certmonger os-timemaster $(EXTRA_TARGETS)
 MODULES?=${TARGETS:=.pp.bz2}
 DATADIR?=/usr/share
 LOCALDIR?=/usr/share/openstack-selinux/master

--- a/os-ovs-el9.te
+++ b/os-ovs-el9.te
@@ -1,0 +1,14 @@
+#
+# openstack-selinux extra OVS policy for RHEL9
+#
+# Allow openvswitch to write to files in /tmp
+#
+policy_module(os-ovs-el9,0.1)
+
+gen_require(`
+	type openvswitch_t;
+	type svirt_t;
+')
+
+# bugzilla 2118908
+allow svirt_t openvswitch_t:anon_inode { read write };


### PR DESCRIPTION
This patch sources /etc/os-release, present on Fedora and derivatives, in order for the build to make decisions about which policy modules to build based on the operating system release.