### PR TITLE
local_settings.sh: Don't check modules when not root

### DIFF
--- a/local_settings.sh.in
+++ b/local_settings.sh.in
@@ -343,7 +343,11 @@ verify_policies() {
 		exit 0
 	fi
 	if [ $(getenforce) != "Enforcing" ]; then
-		echo "SELinux is permissive";
+		echo "SELinux is permissive"
+		exit 0
+	fi
+	if [ "$(id -u)" != "0" ]; then
+		echo "Note: UID is not 0; cannot check SELinux module status"
 		exit 0
 	fi
 


### PR DESCRIPTION
Running 'semodule -l' can only be done as root, but package
verification (e.g. rpm -V) can be done as any user.  Don't
break package verification if running as non-root.