### PR TITLE
Allow init_t to create and mange socket in container_file_t

### DIFF
--- a/os-podman.te
+++ b/os-podman.te
@@ -55,3 +55,6 @@ allow container_t fixed_disk_device_t:blk_file getattr;
 # Bugzilla 2020210
 manage_files_pattern(container_t, container_log_t, container_log_t);
 manage_dirs_pattern(container_t, container_log_t, container_log_t);
+
+# Bugzilla 2091076
+manage_sock_files_pattern(init_t, container_file_t, container_file_t);

--- a/tests/bz2091076
+++ b/tests/bz2091076
@@ -1,0 +1,2 @@
+type=AVC msg=audit(1663231589.213:223510): avc:  denied  { create } for  pid=1 comm="systemd" name="podman.sock" scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:container_file_t:s0 tclass=sock_file permissive=1
+type=AVC msg=audit(1663231589.213:223511): avc:  denied  { write } for  pid=1 comm="systemd" name="podman.sock" dev="vda4" ino=143041949 scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:container_file_t:s0 tclass=sock_file permissive=1


### PR DESCRIPTION
This is needed for some cases, for instance collectd container running podman-remote to get container healthchecks status.

Related: rhbz#2091076