### PR TITLE
Run the verification even on permissive system

### DIFF
--- a/local_settings.sh.in
+++ b/local_settings.sh.in
@@ -342,10 +342,6 @@ verify_policies() {
 		echo "SELinux is disabled"
 		exit 0
 	fi
-	if [ $(getenforce) != "Enforcing" ]; then
-		echo "SELinux is permissive"
-		exit 0
-	fi
 	if [ "$(id -u)" != "0" ]; then
 		echo "Note: UID is not 0; cannot check SELinux module status"
 		exit 0


### PR DESCRIPTION
That way, it will prevent issues in the current upstream CI, while ensuring we can safely switch back to enforcing later.