### PR TITLE
Drop MongoDB

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ EXTRA_TARGETS?=os-ovs-el9
 endif # version 9
 endif # RHEL clones
 
-TARGETS?=os-ovs os-swift os-nova os-neutron os-mysql os-glance os-rsync os-rabbitmq os-keepalived os-keystone os-haproxy os-mongodb os-ipxe os-redis os-cinder os-httpd os-gnocchi os-collectd os-virt os-dnsmasq os-octavia os-podman os-rsyslog os-pbis os-barbican os-logrotate os-certmonger os-timemaster $(EXTRA_TARGETS)
+TARGETS?=os-ovs os-swift os-nova os-neutron os-mysql os-glance os-rsync os-rabbitmq os-keepalived os-keystone os-haproxy os-ipxe os-redis os-cinder os-httpd os-gnocchi os-collectd os-virt os-dnsmasq os-octavia os-podman os-rsyslog os-pbis os-barbican os-logrotate os-certmonger os-timemaster $(EXTRA_TARGETS)
 MODULES?=${TARGETS:=.pp.bz2}
 DATADIR?=/usr/share
 LOCALDIR?=/usr/share/openstack-selinux/master

--- a/local_settings.sh.in
+++ b/local_settings.sh.in
@@ -24,7 +24,6 @@ declare -A custom_fcontext=(
 ["$SHAREDSTATEDIR/designate/bind9(/.*)?"]='named_zone_t'
 ["$SHAREDSTATEDIR/vhost_sockets(/.*)?"]='virt_cache_t'
 ["$SHAREDSTATEDIR/openstack-dashboard"]='httpd_var_lib_t'
-["$SHAREDSTATEDIR/mongodb(/.*)?"]='mongod_var_lib_t'
 ["$LOCALSTATEDIR/log/gnocchi/app.log"]='httpd_log_t'
 ["$LOCALSTATEDIR/log/aodh/app.log"]='httpd_log_t'
 ["$LOCALSTATEDIR/log/ceilometer/app.log"]='httpd_log_t'

--- a/os-mongodb.te
+++ b/os-mongodb.te
@@ -1,1 +1,0 @@
-policy_module(os-mongodb,0.1)

--- a/tests/bz1192049
+++ b/tests/bz1192049
@@ -1,1 +1,0 @@
-type=AVC msg=audit(1424715492.561:319885): avc:  denied  { execmem } for  pid=30884 comm="mongod" scontext=system_u:system_r:mongod_t:s0 tcontext=system_u:system_r:mongod_t:s0 tclass=process


### PR DESCRIPTION
MongoDB was removed from dependencies repo in RDO during the Queens cycle[1].

[1] https://github.com/redhat-openstack/rdoinfo/commit/2df70be02cfdbbb97827dd6361cef20fc8f6adbb