### PR TITLE
Remove leftover of ceilometer-api

### DIFF
--- a/local_settings.sh.in
+++ b/local_settings.sh.in
@@ -26,7 +26,6 @@ declare -A custom_fcontext=(
 ["$SHAREDSTATEDIR/openstack-dashboard"]='httpd_var_lib_t'
 ["$LOCALSTATEDIR/log/gnocchi/app.log"]='httpd_log_t'
 ["$LOCALSTATEDIR/log/aodh/app.log"]='httpd_log_t'
-["$LOCALSTATEDIR/log/ceilometer/app.log"]='httpd_log_t'
 ["$LOCALSTATEDIR/log/panko/app.log"]='httpd_log_t'
 ["$LOCALSTATEDIR/log/zaqar/zaqar.log"]='httpd_log_t'
 ["$LOCALSTATEDIR/lib/config-data(/.*)?"]='container_file_t'


### PR DESCRIPTION
The ceilometer-api service was removed during queens cycle[1].

This removes the remaining definition for ceilometer-api run by httpd and mod_wsgi.

[1] https://github.com/openstack/ceilometer/commit/d881dd52289d453b9f9d94c7c32c0672a70a8064