### PR TITLE
Fix sudo by glance-api

### DIFF
--- a/os-glance.te
+++ b/os-glance.te
@@ -67,6 +67,8 @@ optional_policy(`
 gen_tunable(os_glance_use_sudo, false)
 tunable_policy(`os_glance_use_sudo',`
 	sudo_exec(glance_api_t)
+	auth_use_pam(glance_api_t)
+	init_rw_utmp(glance_api_t)
 	logging_send_audit_msgs(glance_api_t)
 	iscsid_domtrans(glance_api_t)
 	fstools_domtrans(glance_api_t)

--- a/tests/bz2255412
+++ b/tests/bz2255412
@@ -1,0 +1,2 @@
+type=AVC msg=audit(1703084811.884:6481): avc:  denied  { execute } for  pid=72459 comm="sudo" name="unix_chkpwd" dev="vda1" ino=4700890 scontext=system_u:system_r:glance_api_t:s0 tcontext=system_u:object_r:chkpwd_exec_t:s0 tclass=file permissive=0
+type=AVC msg=audit(1703084818.067:6524): avc:  denied  { execute } for  pid=72505 comm="sudo" name="unix_chkpwd" dev="vda1" ino=4700890 scontext=system_u:system_r:glance_api_t:s0 tcontext=system_u:object_r:chkpwd_exec_t:s0 tclass=file permissive=0


### PR DESCRIPTION
The glance-api service requires sudo when cinder backend is used but this has been denied by selinux.

~~~
type=AVC msg=audit(1703084811.884:6481): avc:  denied  { execute } for  pid=72459 comm="sudo" name="unix_chkpwd" dev="vda1" ino=4700890 scontext=system_u:system_r:glance_api_t:s0 tcontext=system_u:object_r:chkpwd_exec_t:s0 tclass=file permissive=0 type=AVC msg=audit(1703084818.067:6524): avc:  denied  { execute } for  pid=72505 comm="sudo" name="unix_chkpwd" dev="vda1" ino=4700890 scontext=system_u:system_r:glance_api_t:s0 tcontext=system_u:object_r:chkpwd_exec_t:s0 tclass=file permissive=0
~~~

This fixes the denial and ensures sudo is actually allowed.

Resolves: rhbz#2255412