### PR TITLE
Fix EL10 compatibility for SELinux policy modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,6 @@ OS_MAJ=$(shell OS_VER=$(OS_VER) && echo $${OS_VER/.*/})
 
 # RHEL & rebuilds: if we match one of these, we do a version comparison.
 ifneq (,$(findstring $(OS_ID),rhel centos rocky almalinux))
-# If version 9 or greater, add extra targets
-ifeq ($(OS_MAJ),9)
-EXTRA_TARGETS?=os-ovs-el9
-endif # version 9
 endif # RHEL clones
 
 TARGETS?=os-ovs os-swift os-nova os-neutron os-mysql os-glance os-rsync os-rabbitmq os-keepalived os-keystone os-haproxy os-ipxe os-redis os-cinder os-httpd os-gnocchi os-collectd os-virt os-dnsmasq os-octavia os-podman os-rsyslog os-barbican os-logrotate os-certmonger os-timemaster os-ceilometer os-net-config os-frr $(EXTRA_TARGETS)

--- a/local_settings.sh.in
+++ b/local_settings.sh.in
@@ -255,8 +255,12 @@ install_policies() {
 	boolean -N -m --on httpd_can_network_connect
 	boolean -N -m --on swift_can_network
 	boolean -N -m --on httpd_use_openstack
-	boolean -N -m --on collectd_tcp_network_connect
 	boolean -N -m --on domain_can_mmap_files"
+
+	# collectd_tcp_network_connect is not available on EL10+
+	if $SBINDIR/semanage boolean -l -n 2>/dev/null | grep -qw collectd_tcp_network_connect; then
+		INPUT="${INPUT}${CR}boolean -N -m --on collectd_tcp_network_connect"
+	fi
 
 	#
 	# Append modules to our semanage script

--- a/os-certmonger.te
+++ b/os-certmonger.te
@@ -3,12 +3,17 @@ policy_module(os-certmonger,0.1)
 gen_require(`
   type certmonger_t;
   type iptables_t;
-  type puppet_etc_t;
   class dir {search};
 ')
-# rhbz#1777263
-allow certmonger_t puppet_etc_t:dir search;
-read_files_pattern(certmonger_t, puppet_etc_t, puppet_etc_t)
+
+optional_policy(`
+  gen_require(`
+    type puppet_etc_t;
+  ')
+  # rhbz#1777263
+  allow certmonger_t puppet_etc_t:dir search;
+  read_files_pattern(certmonger_t, puppet_etc_t, puppet_etc_t)
+')
 
 # rhbz#1777368
 container_runtime_domtrans(certmonger_t)

--- a/os-collectd.te
+++ b/os-collectd.te
@@ -1,18 +1,20 @@
 policy_module(os-collectd,0.1)
 
-gen_require(`
-	type collectd_t;
-	type var_lock_t;
-	type cpu_device_t;
-	class capability sys_rawio;
+optional_policy(`
+	gen_require(`
+		type collectd_t;
+		type var_lock_t;
+		type cpu_device_t;
+		class capability sys_rawio;
+	')
+
+	# Bugzilla #1558465
+	allow collectd_t cpu_device_t:chr_file rw_file_perms;
+
+	# FIXME: Upstream policy probably needs collectd_var_lock_t
+	# and a file transition rule in collectd.te.
+	allow collectd_t var_lock_t:dir add_entry_dir_perms;
+	allow collectd_t var_lock_t:file manage_file_perms;
+	allow collectd_t var_lock_t:lnk_file read_lnk_file_perms;
+	allow collectd_t self:capability sys_rawio;
 ')
-
-# Bugzilla #1558465
-allow collectd_t cpu_device_t:chr_file rw_file_perms;
-
-# FIXME: Upstream policy probably needs collectd_var_lock_t
-# and a file transition rule in collectd.te.
-allow collectd_t var_lock_t:dir add_entry_dir_perms;
-allow collectd_t var_lock_t:file manage_file_perms;
-allow collectd_t var_lock_t:lnk_file read_lnk_file_perms;
-allow collectd_t self:capability sys_rawio;

--- a/os-ovs.te
+++ b/os-ovs.te
@@ -129,3 +129,11 @@ allow openvswitch_t svirt_t:unix_stream_socket { read write };
 
 # bugzilla #1707840
 allow openvswitch_t spc_t:unix_stream_socket { read write };
+
+# bugzilla 2118908 - anon_inode class available on EL9+
+optional_policy(`
+	gen_require(`
+		class anon_inode { read write };
+	')
+	allow svirt_t openvswitch_t:anon_inode { read write };
+')

--- a/os-podman.te
+++ b/os-podman.te
@@ -6,7 +6,6 @@ gen_require(`
         type container_file_t;
         type container_log_t;
         type openvswitch_t;
-        type puppet_etc_t;
         type cluster_var_log_t;
         type init_t;
         type swift_data_t;
@@ -17,11 +16,17 @@ gen_require(`
 #============= container_t ==============
 miscfiles_read_generic_certs(container_t)
 openvswitch_stream_connect(container_t)
-# for posterity: read_files_pattern includes dir accesses
-read_files_pattern(container_t, puppet_etc_t, puppet_etc_t)
-read_lnk_files_pattern(container_t, puppet_etc_t, puppet_etc_t)
-# but read_files_pattern does not allow "read" on tclass=dir
-allow container_t puppet_etc_t:dir { read };
+
+optional_policy(`
+  gen_require(`
+    type puppet_etc_t;
+  ')
+  # for posterity: read_files_pattern includes dir accesses
+  read_files_pattern(container_t, puppet_etc_t, puppet_etc_t)
+  read_lnk_files_pattern(container_t, puppet_etc_t, puppet_etc_t)
+  # but read_files_pattern does not allow "read" on tclass=dir
+  allow container_t puppet_etc_t:dir { read };
+')
 
 # bugzilla #1772025
 allow openvswitch_t container_file_t:dir create;

--- a/os-timemaster.te
+++ b/os-timemaster.te
@@ -1,9 +1,11 @@
 policy_module(os-timemaster,0.1)
 
-gen_require(`
-  type ptp4l_t;
-')
+optional_policy(`
+  gen_require(`
+    type ptp4l_t;
+  ')
 
-# Bugzilla 1872651 referencing RHEL bug 1759214. We need this for 8.2 too.
-allow ptp4l_t self:capability sys_admin;
-allow ptp4l_t self:packet_socket create_socket_perms;
+  # Bugzilla 1872651 referencing RHEL bug 1759214. We need this for 8.2 too.
+  allow ptp4l_t self:capability sys_admin;
+  allow ptp4l_t self:packet_socket create_socket_perms;
+')


### PR DESCRIPTION
RHEL 10 moved collectd, puppet, and linuxptp SELinux modules from selinux-policy-targeted to selinux-policy-epel-targeted [1]. This breaks openstack-selinux on EL10 because:

- puppet_etc_t (os-certmonger, os-podman), collectd_t (os-collectd), ptp4l_t (os-timemaster) are no longer in the base policy
- collectd_tcp_network_connect boolean is undefined
- The single semanage import transaction in local_settings.sh rolls back all module loads when any boolean/type is missing

Wrap missing type references in optional_policy() and conditionally set collectd_tcp_network_connect only when available. Fold the os-ovs-el9 anon_inode rule into os-ovs.te using optional_policy to avoid version-specific modules.

All changes are backward-compatible with EL9.

[1] https://access.redhat.com/articles/7133759